### PR TITLE
feat(recipe-detail): 레시피 상세 화면 구현 및 뷰모델 로직 추가

### DIFF
--- a/__tests__/recipes/Recipe.test.ts
+++ b/__tests__/recipes/Recipe.test.ts
@@ -18,7 +18,7 @@ describe('RecipeSummary 클래스', () => {
             expect(summary.title).toBe(apiResponse.title);
             expect(summary.youtubeId).toBe(apiResponse.youtubeId);
             expect(summary.count).toBe(apiResponse.count);
-            expect(summary.createdAt.getTime()).toBe(new Date(apiResponse.createdAt).getTime());;
+            expect(summary.createdAt.getTime()).toBe(new Date(apiResponse.createdAt).getTime());
         });
 
         it('createdAt이 잘못된 날짜일 경우 Invalid Date가 되어야 한다', () => {

--- a/__tests__/recipes/Recipe.test.ts
+++ b/__tests__/recipes/Recipe.test.ts
@@ -1,0 +1,35 @@
+import { RecipeSummary } from '@/src/features/recipe/types/RecipeSummary';
+import { RecipeSummaryApiResponse } from '@/src/features/recipe/api/recipe';
+
+describe('RecipeSummary 클래스', () => {
+    describe('create 메서드는', () => {
+        const apiResponse: RecipeSummaryApiResponse = {
+            recipeId: 'r123',
+            title: '계란말이',
+            youtubeId: 'yt12345',
+            count: 42,
+            createdAt: '2024-05-01T12:00:00Z',
+        };
+
+        it('API 응답을 기반으로 RecipeSummary 인스턴스를 생성해야 한다', () => {
+            const summary = RecipeSummary.create(apiResponse);
+
+            expect(summary.recipeId).toBe(apiResponse.recipeId);
+            expect(summary.title).toBe(apiResponse.title);
+            expect(summary.youtubeId).toBe(apiResponse.youtubeId);
+            expect(summary.count).toBe(apiResponse.count);
+            expect(summary.createdAt.getTime()).toBe(new Date(apiResponse.createdAt).getTime());;
+        });
+
+        it('createdAt이 잘못된 날짜일 경우 Invalid Date가 되어야 한다', () => {
+            const invalidApiResponse = {
+                ...apiResponse,
+                createdAt: 'invalid-date',
+            };
+
+            const summary = RecipeSummary.create(invalidApiResponse);
+
+            expect(isNaN(summary.createdAt.getTime())).toBe(true);
+        });
+    });
+});

--- a/__tests__/recipes/RecipeCard.test.tsx
+++ b/__tests__/recipes/RecipeCard.test.tsx
@@ -1,0 +1,41 @@
+import {RecipeCard} from "@/src/features/recipe/components/RecipeCard";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import {recipeSummariesMock} from "@/src/features/recipe/__mocks__/fetchRecipe.mock";
+
+jest.mock('@/src/features/recipe/hooks/useRecipeMeta', () => ({
+    useRecipeMeta: (youtubeId: string) => ({
+        thumbnail: `https://mocked-thumbnail.com/${youtubeId}`,
+    }),
+}));
+
+describe('RecipeCard 가 주어졌을 때', () => {
+
+    const sampleRecipes = Object.values(recipeSummariesMock);
+
+    describe('레시피 정보를 렌더링하는 경우', () => {
+
+        sampleRecipes.forEach((recipe) => {
+            it('썸네일 이미지를 표시해야 한다', () => {
+                render(<RecipeCard recipe={recipe} onPress={() => {}} />);
+                const image = screen.getByTestId('recipe-image');
+                expect(image.props.source.uri).toBe(`https://mocked-thumbnail.com/${recipe.youtubeId}`);
+            });
+
+            it('제목 텍스트를 화면에 표시해야 한다', () => {
+                render(<RecipeCard recipe={recipe} onPress={() => {}} />);
+                expect(screen.getByText(recipe.title)).toBeTruthy();
+            });
+        });
+    });
+
+    describe('카드를 클릭한 경우', () => {
+        sampleRecipes.forEach((recipe) => {
+            it(`onPress 콜백이 ${recipe.title} 레시피로 호출되어야 한다`, () => {
+                const mockPress = jest.fn();
+                render(<RecipeCard recipe={recipe} onPress={mockPress} />);
+                fireEvent.press(screen.getByTestId(`recipe-card-${recipe.recipeId}`));
+                expect(mockPress).toHaveBeenCalledWith(recipe);
+            });
+        });
+    });
+});

--- a/__tests__/recipes/RecipeDetail.test.ts
+++ b/__tests__/recipes/RecipeDetail.test.ts
@@ -1,0 +1,74 @@
+import { RecipeDetail } from '@/src/features/recipe/types/RecipeDetail';
+import {recipeDetailApiMock} from '@/src/features/recipe/__mocks__/fetchRecipe.mock';
+
+describe('RecipeDetail 클래스를 사용 할때', () => {
+
+    const defaultParams = {
+        initialRecipeId: 'success-id',
+        initialTitle: '초기 제목',
+        initialYoutubeId: 'initial-yt-id',
+    };
+
+    describe('formatTime 메서드는', () => {
+        it.each([
+            [0, '준비 시간 없음'],
+            [-5, '준비 시간 없음'],
+            [10, '10분'],
+            [60, '1시간'],
+            [75, '1시간 15분'],
+            [120, '2시간'],
+        ])('총 소요시간이 %i분일 때 "%s"을(를) 반환해야 한다', (input, expected) => {
+            expect(RecipeDetail.formatTime(input)).toBe(expected);
+        });
+    });
+
+    describe('create 메서드는', () => {
+        it('초기 값들을 갖는 RecipeDetail 인스턴스를 생성해야 한다', () => {
+            const recipe = RecipeDetail.create(defaultParams.initialRecipeId, defaultParams.initialTitle, defaultParams.initialYoutubeId);
+
+            expect(recipe.recipeId).toBe(defaultParams.initialRecipeId);
+            expect(recipe.title).toBe(defaultParams.initialTitle);
+            expect(recipe.youtubeId).toBe(defaultParams.initialYoutubeId);
+            expect(recipe.summary).toBe('');
+            expect(recipe.totalTime).toBe('');
+            expect(recipe.ingredients).toEqual([]);
+            expect(recipe.steps).toEqual([]);
+        });
+
+        it('title과 youtubeId가 없으면 빈 문자열로 설정되어야 한다', () => {
+            const recipe = RecipeDetail.create(defaultParams.initialRecipeId);
+
+            expect(recipe.title).toBe('');
+            expect(recipe.youtubeId).toBe('');
+        });
+    });
+
+    describe('updateDetails 메서드는', () => {
+        it('API 응답 값을 기반으로 새로운 RecipeDetail 인스턴스를 반환해야 한다', () => {
+            const initial = RecipeDetail.create(defaultParams.initialRecipeId, defaultParams.initialTitle, defaultParams.initialYoutubeId);
+
+            const updated = initial.updateDetails(recipeDetailApiMock);
+
+
+            expect(updated.recipeId).toBe(defaultParams.initialRecipeId);
+            expect(updated.title).toBe(recipeDetailApiMock.title);
+            expect(updated.youtubeId).toBe(recipeDetailApiMock.youtubeId);
+            expect(updated.summary).toBe(recipeDetailApiMock.summary);
+            expect(updated.totalTime).toBe(RecipeDetail.formatTime(recipeDetailApiMock.totalTime));
+            expect(updated.ingredients).toEqual(recipeDetailApiMock.ingredients);
+            updated.steps.forEach(
+                (step, index) => {
+                    const apiStep = recipeDetailApiMock.steps[index];
+                    expect(step.stepId).toBe(apiStep.stepId);
+                }
+            )
+        });
+
+        it('기존 인스턴스와는 다른 객체를 반환해야 한다', () => {
+            const recipe = RecipeDetail.create(defaultParams.initialRecipeId, defaultParams.initialTitle, defaultParams.initialYoutubeId);
+            const updated = recipe.updateDetails(recipeDetailApiMock);
+
+            expect(updated).not.toBe(recipe);
+        });
+    });
+});

--- a/__tests__/recipes/useRecipeListViewModel.test.ts
+++ b/__tests__/recipes/useRecipeListViewModel.test.ts
@@ -1,0 +1,86 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import * as api from '@/src/features/recipe/api/recipe';
+import { useRecipeListViewModel } from '@/src/features/recipe/viewmodels/useRecipeListViewModel';
+import {RecipeSummaryApiResponse} from "@/src/features/recipe/api/recipe";
+
+jest.mock('@/src/features/recipe/api/recipe');
+
+const mockRecipes: RecipeSummaryApiResponse[] = [
+    {
+        recipeId: '1',
+        title: '레시피 1',
+        youtubeId: 'yt1',
+        count: 10,
+        createdAt: '2023-10-01T12:00:00Z',
+    },
+    {
+        recipeId: '2',
+        title: '레시피 2',
+        youtubeId: 'yt2',
+        count: 5,
+        createdAt: '2023-10-02T12:00:00Z',
+    },
+];
+
+describe('레시피 리스트 ViewModel을 사용할 때', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    describe('초기 렌더링이 되면', () => {
+        it('recipes는 빈 배열이고, loading은 true이며 error는 null이어야 한다', () => {
+            const { result } = renderHook(() => useRecipeListViewModel());
+
+            const { recipes, loading, error } = result.current;
+
+            expect(recipes).toEqual([]);
+            expect(loading).toBe(true);
+            expect(error).toBeNull();
+        });
+    });
+
+    describe('레시피 요약 API 호출이 성공하면', () => {
+        it('recipes 상태에 데이터를 채우고 loading은 false가 되어야 한다', async () => {
+            (api.fetchRecipeSummary as jest.Mock).mockResolvedValue(mockRecipes);
+
+            const { result } = renderHook(() => useRecipeListViewModel());
+
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            const { recipes, loading, error } = result.current;
+
+            expect(loading).toBe(false);
+            expect(error).toBeNull();
+
+            expect(recipes.length).toBe(mockRecipes.length);
+
+            recipes.forEach((recipe, index) => {
+                const expected = mockRecipes[index];
+
+                expect(recipe.recipeId).toBe(expected.recipeId);
+                expect(recipe.title).toBe(expected.title);
+                expect(recipe.youtubeId).toBe(expected.youtubeId);
+                expect(recipe.count).toBe(expected.count);
+                expect(recipe.createdAt.getTime()).toBe(new Date(expected.createdAt).getTime());
+            });
+        });
+    });
+
+
+    describe('레시피 요약 API 호출이 실패하면', () => {
+        it('error 상태에 에러를 저장하고 recipes는 빈 배열이어야 한다', async () => {
+            const mockError = new Error('API 실패');
+            (api.fetchRecipeSummary as jest.Mock).mockRejectedValue(mockError);
+
+            const { result } = renderHook(() => useRecipeListViewModel());
+
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            const { recipes, loading, error } = result.current;
+
+            expect(loading).toBe(false);
+            expect(error).toEqual(mockError);
+            expect(recipes).toEqual([]);
+        });
+    });
+});

--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -1,0 +1,16 @@
+import { Tabs } from 'expo-router';
+
+export default function TabLayout() {
+    return (
+        <Tabs>
+            <Tabs.Screen name="index" options={{
+                headerTitle: '쉐프토리',
+                tabBarLabel: '홈'
+            }} />
+            <Tabs.Screen name="profile" options={{
+                headerTitle: '프로필' ,
+                tabBarLabel: '마이'
+            }} />
+        </Tabs>
+    );
+}

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -1,0 +1,47 @@
+
+import {Text, View, StyleSheet } from 'react-native';
+import React from "react";
+import {RecipeList} from "@/src/features/recipe/components/RecipeList";
+import {useRecipeListViewModel} from "@/src/features/recipe/viewmodels/useRecipeListViewModel";
+import {LinkInput} from "@/src/features/summary/components/LinkInput";
+import {HomeSectionHeader} from "@/src/shared/components/HomeSectionHeader";
+import {useRouter} from "expo-router";
+import {RecipeSummary} from "@/src/features/recipe/types/RecipeSummary";
+import {LoadingView} from "@/src/shared/components/LoadingView";
+
+export default function HomeScreen() {
+    const { recipes, loading } = useRecipeListViewModel();
+    const router = useRouter();
+
+    const handleRecipePress = ({ recipeId, youtubeId, title } : RecipeSummary) => {
+        router.push({
+            pathname: '/recipe/[recipeId]',
+            params: { recipeId, youtubeId, title },
+        });
+    };
+
+    return (
+        <LoadingView loading={loading}>
+            <View style={styles.wrapper}>
+                <Text style={styles.title}>레시피를 요약하고, 저장하세요</Text>
+                <LinkInput placeholder={'링크를 입력하세요... youtube, 블로그 etc'} />
+                <HomeSectionHeader title="추천 레시피" onPress={() => {}} />
+                <RecipeList recipes={recipes} onPress={handleRecipePress} />
+                <HomeSectionHeader title="최근 본 레시피" onPress={() => {}} />
+                <RecipeList recipes={recipes} onPress={handleRecipePress} />
+            </View>
+        </LoadingView>
+    );
+}
+
+const styles = StyleSheet.create({
+    wrapper: {
+        flex: 1,
+        padding: 20,
+        backgroundColor: '#fff',
+    },
+    title: {
+        fontSize: 20,
+        fontWeight: '600',
+    },
+});

--- a/src/app/+not-found.tsx
+++ b/src/app/+not-found.tsx
@@ -1,0 +1,30 @@
+import { View, StyleSheet } from 'react-native';
+import { Link, Stack } from 'expo-router';
+
+export default function NotFoundScreen() {
+    return (
+        <>
+            <Stack.Screen options={{ title: 'Oops! Not Found' }} />
+            <View style={styles.wrapper}>
+                <Link href="./" style={styles.button}>
+                    Go back to Home screen!
+                </Link>
+            </View>
+        </>
+    );
+}
+
+const styles = StyleSheet.create({
+    wrapper: {
+        flex: 1,
+        backgroundColor: '#25292e',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+
+    button: {
+        fontSize: 20,
+        textDecorationLine: 'underline',
+        color: '#fff',
+    },
+});

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,0 +1,16 @@
+
+import {Stack} from 'expo-router';
+import {CustomBackButton} from "@/src/shared/components/CustomBackButton";
+
+export default function RootLayout() {
+  return (
+      <Stack
+          screenOptions={{
+              headerBackVisible: false,
+              headerLeft: () => <CustomBackButton />,
+          }}
+      >
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+      </Stack>
+  );
+}

--- a/src/app/recipe/[recipeId].tsx
+++ b/src/app/recipe/[recipeId].tsx
@@ -1,0 +1,97 @@
+import {Stack, useLocalSearchParams} from 'expo-router';
+import {StyleSheet, View} from 'react-native';
+import React, {useRef} from 'react';
+import { useRecipeDetailViewModel } from '@/src/features/recipe/viewmodels/useRecipeDetailViewModel';
+import {LoadingView} from "@/src/shared/components/LoadingView";
+import {RecipeVideo} from "@/src/features/recipe/components/RecipeVideo";
+import {RecipeOverview} from "@/src/features/recipe/components/RecipeOverview";
+import {CookStepsCarousel} from "@/src/features/recipe/cook/components/CookStepsCarousel";
+import {YoutubeIframeRef} from "react-native-youtube-iframe";
+import {RecipeMode} from "@/src/features/recipe/types/RecipeMode";
+
+export default function RecipeDetailScreen() {
+    const { recipeId, youtubeId, title } = useLocalSearchParams<{ recipeId: string, youtubeId?: string, title?: string }>();
+    const { recipe, loading } = useRecipeDetailViewModel(recipeId, youtubeId, title);
+    const [mode, setMode] = React.useState<RecipeMode>(RecipeMode.Detail);
+    const playerRef = useRef<YoutubeIframeRef>(null);
+
+    const screens = {
+        [RecipeMode.Detail]: (
+            <RecipeOverview
+                recipe={recipe}
+                onStart={() => setMode(RecipeMode.Cook)}
+            />
+        ),
+        [RecipeMode.Cook]: (
+            <CookStepsCarousel
+                recipe={recipe}
+                playerRef={playerRef}
+                onExit={() => setMode(RecipeMode.Detail)}
+            />
+        ),
+    };
+
+
+    return (
+        <>
+            <Stack.Screen options={{ title: recipe.title }} />
+            <View style={styles.wrapper}>
+                <RecipeVideo
+                    videoId={recipe.youtubeId}
+                    ref={playerRef}
+                />
+                <LoadingView loading={loading}>
+                    {screens[mode]}
+                </LoadingView>
+            </View>
+        </>
+    );
+}
+
+const styles = StyleSheet.create({
+    wrapper: {
+        flex: 1,
+        backgroundColor: '#fff',
+    },
+    container: {
+        paddingBottom: 100,
+    },
+    detail: {
+        padding: 20,
+    },
+    startButton: {
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        backgroundColor: '#f33',
+        paddingVertical: 18,
+        alignItems: 'center',
+    },
+    startButtonText: {
+        color: '#fff',
+        fontWeight: 'bold',
+        fontSize: 16,
+    },
+    title: {
+        fontSize: 24,
+        fontWeight: 'bold',
+        marginBottom: 12,
+    },
+    summary: {
+        fontSize: 16,
+        color: '#555',
+        marginBottom: 20,
+    },
+    sectionTitle: {
+        fontSize: 18,
+        fontWeight: '600',
+        marginTop: 16,
+        marginBottom: 6,
+    },
+    content: {
+        fontSize: 15,
+        color: '#333',
+        marginBottom: 4,
+    },
+});

--- a/src/app/recipe/[recipeId].tsx
+++ b/src/app/recipe/[recipeId].tsx
@@ -15,22 +15,6 @@ export default function RecipeDetailScreen() {
     const [mode, setMode] = React.useState<RecipeMode>(RecipeMode.Detail);
     const playerRef = useRef<YoutubeIframeRef>(null);
 
-    const screens = {
-        [RecipeMode.Detail]: (
-            <RecipeOverview
-                recipe={recipe}
-                onStart={() => setMode(RecipeMode.Cook)}
-            />
-        ),
-        [RecipeMode.Cook]: (
-            <CookStepsCarousel
-                recipe={recipe}
-                playerRef={playerRef}
-                onExit={() => setMode(RecipeMode.Detail)}
-            />
-        ),
-    };
-
 
     return (
         <>
@@ -41,11 +25,23 @@ export default function RecipeDetailScreen() {
                     ref={playerRef}
                 />
                 <LoadingView loading={loading}>
-                    {screens[mode]}
+                    {mode === RecipeMode.Detail ? (
+                        <RecipeOverview
+                            recipe={recipe}
+                            onStart={() => setMode(RecipeMode.Cook)}
+                        />
+                    ) : mode === RecipeMode.Cook ? (
+                        <CookStepsCarousel
+                            recipe={recipe}
+                            playerRef={playerRef}
+                            onExit={() => setMode(RecipeMode.Detail)}
+                        />
+                    ) : null}
                 </LoadingView>
             </View>
         </>
     );
+
 }
 
 const styles = StyleSheet.create({

--- a/src/features/recipe/__mocks__/fetchRecipe.mock.ts
+++ b/src/features/recipe/__mocks__/fetchRecipe.mock.ts
@@ -1,0 +1,70 @@
+import {RecipeSummary} from "@/src/features/recipe/types/RecipeSummary";
+import {RecipeDetailApiResponse, RecipeSummaryApiResponse} from "@/src/features/recipe/api/recipe";
+
+export const recipeDetailApiMock: RecipeDetailApiResponse = {
+    title: '백종원의 제육볶음',
+    summary: '매콤달콤한 양념으로 밥도둑 제육볶음을 완성해보세요.',
+    ingredients: [
+        '돼지고기 앞다리살',
+        '양파',
+        '대파',
+        '고추장',
+        '고춧가루',
+        '간장',
+        '설탕',
+        '다진 마늘',
+        '참기름',
+        '후추'
+    ],
+    steps: [
+        {
+            stepId: 'step1-Id',
+            index: 1,
+            description: '돼지고기를 먹기 좋은 크기로 썬다.',
+            startTime: 0,
+            endTime: 5
+        },
+        {
+            stepId: 'step2-Id',
+            index: 2,
+            description: '양파와 대파를 채 썬다.',
+            startTime: 5,
+            endTime: 10
+        },
+        {
+            stepId: 'step3-Id',
+            index: 3,
+            description: '양념장을 만들어 재료와 섞는다.',
+            startTime: 10,
+            endTime: 15
+        },
+        {
+            stepId: 'step4-Id',
+            index: 4,
+            description: '팬에 재료를 볶아 완성한다.',
+            startTime: 15,
+            endTime: 25
+        }
+    ],
+    totalTime: 25,
+    youtubeId: 'j7s9VRsrm9o'
+};
+
+export const recipeSummariesApiMock: Record<string, RecipeSummaryApiResponse> = {
+    '1': {
+        recipeId: '1',
+        title: '백종원의 제육볶음',
+        youtubeId: 'j7s9VRsrm9o',
+        count: 120,
+        createdAt: '2023-10-01T12:00:00Z'
+    },
+    '2': {
+        recipeId: '2',
+        title: '백종원의 제육볶음',
+        youtubeId: 'j7s9VRsrm9o',
+        count: 120,
+        createdAt: '2023-10-01T12:00:00Z'
+    }
+}
+
+export const recipeSummariesMock: RecipeSummary[] = Object.values(recipeSummariesApiMock).map(apiResponse => RecipeSummary.create(apiResponse));

--- a/src/features/recipe/api/recipe.ts
+++ b/src/features/recipe/api/recipe.ts
@@ -1,0 +1,48 @@
+import {recipeDetailApiMock, recipeSummariesApiMock} from "@/src/features/recipe/__mocks__/fetchRecipe.mock";
+
+export interface RecipeDetailApiResponse {
+    title: string;
+    summary: string;
+    ingredients: string[];
+    steps: CookStepApiResponse[];
+    totalTime: number;
+    youtubeId: string;
+}
+
+export interface CookStepApiResponse {
+    stepId: string;
+    index: number;
+    description: string;
+    startTime: number;
+    endTime: number;
+}
+
+export interface RecipeSummaryApiResponse {
+    recipeId: string;
+    title: string;
+    youtubeId: string;
+    count: number;
+    createdAt: string;
+}
+
+export async function fetchRecipeDetail(recipeId: string): Promise<RecipeDetailApiResponse> {
+    return new Promise((resolve, reject) => {
+        setTimeout(() => {
+            const recipe = recipeDetailApiMock;
+            if (!recipe) {
+                reject(new Error('레시피를 찾을 수 없습니다.'));
+            } else {
+                resolve(recipe);
+            }
+        }, 1000);
+    });
+}
+
+export async function fetchRecipeSummary(): Promise<RecipeSummaryApiResponse[]> {
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            const recipes = Object.values(recipeSummariesApiMock)
+            resolve(recipes);
+        }, 1000);
+    });
+}

--- a/src/features/recipe/components/RecipeCard.tsx
+++ b/src/features/recipe/components/RecipeCard.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import {Image, Pressable, StyleSheet, Text} from 'react-native';
+import { RecipeSummary } from "@/src/features/recipe/types/RecipeSummary";
+import {useRecipeMeta} from "@/src/features/recipe/hooks/useRecipeMeta";
+
+type Props = {
+    recipe: RecipeSummary;
+    onPress: (recipe: RecipeSummary) => void;
+};
+
+export function RecipeCard({ recipe, onPress }: Props) {
+
+    const { thumbnail } = useRecipeMeta(recipe.youtubeId);
+
+    return (
+        <Pressable
+            testID={`recipe-card-${recipe.recipeId}`}
+            onPress={() => onPress(recipe)}
+            style={styles.card}
+        >
+            <Image testID="recipe-image" source={{ uri: thumbnail }} style={styles.image} />
+            <Text numberOfLines={2} style={styles.cardText}>{recipe.title}</Text>
+        </Pressable>
+    );
+}
+
+const styles = StyleSheet.create({
+    card: { width: '48%', marginTop: 12 },
+    image: { width: '100%', height: 100, borderRadius: 12 },
+    cardText: { marginTop: 6, fontSize: 13 },
+});

--- a/src/features/recipe/components/RecipeList.tsx
+++ b/src/features/recipe/components/RecipeList.tsx
@@ -1,0 +1,27 @@
+import {FlatList, StyleSheet} from 'react-native';
+import {RecipeSummary} from "@/src/features/recipe/types/RecipeSummary";
+import {RecipeCard} from "@/src/features/recipe/components/RecipeCard";
+
+type Props = {
+    recipes: RecipeSummary[];
+    onPress: (recipe: RecipeSummary) => void;
+};
+
+export function RecipeList({ recipes, onPress }: Props) {
+    return (
+        <FlatList
+            data={recipes}
+            numColumns={2}
+            scrollEnabled={false}
+            keyExtractor={(item) => item.recipeId}
+            columnWrapperStyle={styles.columnWrapper}
+            renderItem={({ item }) => (
+                <RecipeCard recipe={item} onPress={onPress} />
+            )}
+        />
+    );
+}
+
+const styles = StyleSheet.create({
+    columnWrapper: {justifyContent: 'space-between'},
+});

--- a/src/features/recipe/components/RecipeOverview.tsx
+++ b/src/features/recipe/components/RecipeOverview.tsx
@@ -1,0 +1,62 @@
+import { RecipeDetail } from '@/src/features/recipe/types/RecipeDetail';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import React from 'react';
+
+type Props = {
+    recipe: RecipeDetail;
+    onStart: () => void;
+};
+
+export function RecipeOverview({ recipe, onStart }: Props) {
+    return (
+        <View style={styles.wrapper}>
+            <ScrollView contentContainerStyle={styles.container}>
+                <View style={styles.detail}>
+                    <Text style={styles.title}>{recipe.title}</Text>
+                    <Text style={styles.summary}>{recipe.summary}</Text>
+
+                    <Text style={styles.sectionTitle}>소요 시간</Text>
+                    <Text style={styles.content}>{recipe.totalTime}</Text>
+
+                    <Text style={styles.sectionTitle}>재료</Text>
+                    {recipe.ingredients.map((item, index) => (
+                        <Text key={index} style={styles.content}>
+                            {index + 1}. {item}
+                        </Text>
+                    ))}
+
+                    <Text style={styles.sectionTitle}>조리 단계</Text>
+                    {recipe.steps.map((step, index) => (
+                        <Text key={index} style={styles.content}>
+                            {index + 1}. {step.description}
+                        </Text>
+                    ))}
+                </View>
+            </ScrollView>
+
+            <Pressable style={styles.startButton} onPress={onStart}>
+                <Text style={styles.startButtonText}>조리 시작하기</Text>
+            </Pressable>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    wrapper: { flex: 1, backgroundColor: '#fff' },
+    container: { paddingBottom: 100 },
+    detail: { padding: 20 },
+    startButton: {
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        backgroundColor: '#f33',
+        paddingVertical: 18,
+        alignItems: 'center',
+    },
+    startButtonText: { color: '#fff', fontWeight: 'bold', fontSize: 16 },
+    title: { fontSize: 24, fontWeight: 'bold', marginBottom: 12 },
+    summary: { fontSize: 16, marginBottom: 20 },
+    sectionTitle: { fontSize: 18, fontWeight: '600', marginTop: 16, marginBottom: 6 },
+    content: { fontSize: 15, marginBottom: 4 },
+});

--- a/src/features/recipe/components/RecipeVideo.tsx
+++ b/src/features/recipe/components/RecipeVideo.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import YoutubePlayer, {YoutubeIframeRef} from 'react-native-youtube-iframe';
+
+type Props = {
+    ref : React.Ref<YoutubeIframeRef | null>;
+    videoId: string;
+};
+
+export function RecipeVideo({ videoId, ref }: Props) {
+    return (
+        <YoutubePlayer height={230} ref={ref} play={true} videoId={videoId} />
+    );
+}

--- a/src/features/recipe/hooks/useRecipeMeta.ts
+++ b/src/features/recipe/hooks/useRecipeMeta.ts
@@ -1,0 +1,14 @@
+import {useEffect, useState} from "react";
+import {getYoutubeMeta} from "react-native-youtube-iframe";
+
+export function useRecipeMeta(youtubeId: string) {
+    const [thumbnail, setThumbnail] = useState(`https://img.youtube.com/vi/${youtubeId}/hqdefault.jpg`);
+
+    useEffect(() => {
+        getYoutubeMeta(youtubeId).then(meta => {
+            if (meta.thumbnail_url) setThumbnail(meta.thumbnail_url);
+        });
+    }, [youtubeId]);
+
+    return { thumbnail };
+}

--- a/src/features/recipe/types/RecipeDetail.ts
+++ b/src/features/recipe/types/RecipeDetail.ts
@@ -1,0 +1,69 @@
+import {RecipeDetailApiResponse} from "@/src/features/recipe/api/recipe";
+import {CookStep} from "@/src/features/recipe/cook/types/CookStep";
+
+export class RecipeDetail {
+    recipeId: string;
+    title: string;
+    youtubeId: string;
+    summary: string;
+    totalTime: string;
+    ingredients: string[];
+    steps: CookStep[];
+
+    private constructor(
+        recipeId: string,
+        title: string,
+        youtubeId: string,
+        summary: string,
+        totalTime: string,
+        ingredients: string[],
+        steps: CookStep[]
+    ) {
+        this.recipeId = recipeId;
+        this.title = title;
+        this.youtubeId = youtubeId;
+        this.summary = summary;
+        this.totalTime = totalTime;
+        this.ingredients = ingredients;
+        this.steps = steps
+    }
+
+    static create(
+        recipeId: string,
+        title?: string,
+        youtubeId?: string
+    ): RecipeDetail {
+        return new RecipeDetail(recipeId, title ?? '', youtubeId ?? '', '', '', [], []);
+    }
+
+    updateDetails(
+        apiResponse: RecipeDetailApiResponse
+    ): RecipeDetail {
+        return new RecipeDetail(
+            this.recipeId,
+            apiResponse.title,
+            apiResponse.youtubeId,
+            apiResponse.summary,
+            RecipeDetail.formatTime(apiResponse.totalTime),
+            apiResponse.ingredients,
+            apiResponse.steps.map(step => CookStep.of(step))
+        );
+    }
+
+    static formatTime(totalTime: number): string {
+        if (totalTime <= 0) {
+            return '준비 시간 없음';
+        }
+
+        const hours = Math.floor(totalTime / 60);
+        const minutes = totalTime % 60;
+
+        if (hours > 0 && minutes > 0) {
+            return `${hours}시간 ${minutes}분`;
+        } else if (hours > 0) {
+            return `${hours}시간`;
+        } else {
+            return `${minutes}분`;
+        }
+    }
+}

--- a/src/features/recipe/types/RecipeMode.ts
+++ b/src/features/recipe/types/RecipeMode.ts
@@ -1,0 +1,4 @@
+export enum RecipeMode {
+    Detail = 'detail',
+    Cook = 'cook',
+}

--- a/src/features/recipe/types/RecipeSummary.ts
+++ b/src/features/recipe/types/RecipeSummary.ts
@@ -1,0 +1,30 @@
+import {RecipeSummaryApiResponse} from "@/src/features/recipe/api/recipe";
+
+
+export class RecipeSummary {
+    recipeId: string;
+    title: string;
+    youtubeId: string;
+    count: number;
+    createdAt: Date;
+
+    private constructor(
+        recipeId: string,
+        title: string,
+        youtubeId: string,
+        count: number,
+        createdAt: Date,
+    ) {
+        this.recipeId = recipeId;
+        this.title = title;
+        this.youtubeId = youtubeId;
+        this.count = count;
+        this.createdAt = createdAt;
+    }
+
+    static create(
+        apiResponse: RecipeSummaryApiResponse
+    ): RecipeSummary {
+        return new RecipeSummary(apiResponse.recipeId, apiResponse.title , apiResponse.youtubeId,apiResponse.count,new Date(apiResponse.createdAt));
+    }
+}

--- a/src/features/recipe/viewmodels/useRecipeDetailViewModel.ts
+++ b/src/features/recipe/viewmodels/useRecipeDetailViewModel.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { RecipeDetail } from '@/src/features/recipe/types/RecipeDetail';
+import { fetchRecipeDetail } from '@/src/features/recipe/api/recipe';
+
+
+export function useRecipeDetailViewModel(
+    recipeId: string,
+    initialYoutubeId?: string,
+    initialTitle?: string
+): {
+    recipe: RecipeDetail;
+    loading: boolean;
+    error: Error | null;
+} {
+    const [recipe, setRecipe] = useState<RecipeDetail>(
+        RecipeDetail.create(recipeId, initialTitle, initialYoutubeId)
+    );
+
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<Error | null>(null);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const data = await fetchRecipeDetail(recipeId);
+                setRecipe(prev => prev.updateDetails(data));
+            } catch (err) {
+                setError(err as Error);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        void fetchData();
+    },  [recipeId, initialTitle, initialYoutubeId]);
+
+    return { recipe, loading, error };
+}

--- a/src/features/recipe/viewmodels/useRecipeListViewModel.ts
+++ b/src/features/recipe/viewmodels/useRecipeListViewModel.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+import {RecipeSummary} from "@/src/features/recipe/types/RecipeSummary";
+import {fetchRecipeSummary} from "@/src/features/recipe/api/recipe";
+
+
+export function useRecipeListViewModel(): { recipes: RecipeSummary[]; loading: boolean; error: Error | null } {
+    const [recipes, setRecipes] = useState<RecipeSummary[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<Error | null>(null);
+
+    useEffect(() => {
+        const fetchRecipes = async () => {
+            try {
+                const data = await fetchRecipeSummary()
+                setRecipes(data.map(recipe => RecipeSummary.create(recipe)));            } catch (error) {
+                setError(error as Error);
+                setRecipes([]);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        void fetchRecipes();
+    }, []);
+
+    return { recipes, loading, error };
+}

--- a/src/features/summary/components/LinkInput.tsx
+++ b/src/features/summary/components/LinkInput.tsx
@@ -1,0 +1,27 @@
+import {StyleSheet, TextInput, TextInputProps} from "react-native";
+
+type LinkInputProps = TextInputProps & {
+    placeholder: string; // 필수로 받도록 설정
+};
+
+export function LinkInput({ placeholder, ...props }: LinkInputProps) {
+    return (
+        <TextInput
+            placeholder={placeholder}
+            style={styles.input}
+            {...props}
+        />
+    );
+}
+
+const styles = StyleSheet.create({
+    input: {
+        marginTop: 16,
+        borderWidth: 1,
+        borderColor: '#ccc',
+        borderRadius: 12,
+        padding: 12,
+        fontSize: 14,
+        backgroundColor: '#f9f9f9',
+    },
+})

--- a/src/shared/components/CustomBackButton.tsx
+++ b/src/shared/components/CustomBackButton.tsx
@@ -1,0 +1,16 @@
+import {useRouter} from "expo-router";
+import {TouchableOpacity} from "react-native";
+import {Ionicons} from "@expo/vector-icons";
+
+export function CustomBackButton() {
+    const router = useRouter();
+
+    return (
+        <TouchableOpacity
+            style={{ paddingHorizontal: 12 }}
+            onPress={() => router.back()}
+        >
+            <Ionicons name="chevron-back" size={24} color="black" />
+        </TouchableOpacity>
+    );
+}

--- a/src/shared/components/HomeSectionHeader.tsx
+++ b/src/shared/components/HomeSectionHeader.tsx
@@ -1,0 +1,33 @@
+import {StyleSheet, TouchableOpacity, View, Text} from "react-native";
+import React from "react";
+
+export function HomeSectionHeader({title, onPress}: { title: string; onPress?: () => void;
+}) {
+    return (
+        <View style={styles.header}>
+            <Text style={styles.title}>{title}</Text>
+            {onPress && (
+                <TouchableOpacity onPress={onPress}>
+                    <Text style={styles.viewAll}>전체 보기</Text>
+                </TouchableOpacity>
+            )}
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    header: {
+        marginTop: 24,
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+    },
+    title: {
+        fontSize: 16,
+        fontWeight: 'bold',
+    },
+    viewAll: {
+        fontSize: 14,
+        color: '#888',
+    },
+});

--- a/src/shared/components/LoadingView.tsx
+++ b/src/shared/components/LoadingView.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { StyleSheet } from "react-native";
+import Skeleton from "react-native-reanimated-skeleton";
+
+type Props = {
+    loading: boolean;
+    children: React.ReactNode;
+};
+
+export function LoadingView({ loading, children }: Props) {
+    return (
+        <Skeleton
+            isLoading={loading}
+            containerStyle={loading ? styles.container : undefined}
+            layout={[
+                { key: 'header', width: '100%', height: 220, borderRadius: 12, marginBottom: 20 },
+                { key: 'title', width: '60%', height: 24, borderRadius: 4, marginBottom: 12 },
+                { key: 'subtitle', width: '80%', height: 18, borderRadius: 4, marginBottom: 20 },
+                { key: 'block-1', width: '90%', height: 14, borderRadius: 4, marginBottom: 10 },
+                { key: 'block-2', width: '85%', height: 14, borderRadius: 4, marginBottom: 10 },
+                { key: 'block-3', width: '70%', height: 14, borderRadius: 4, marginBottom: 10 },            ]}
+            boneColor="#E1E9EE"
+            highlightColor="#F2F8FC"
+            animationType="shiver"
+        >
+            {children}
+        </Skeleton>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 20,
+    },
+});


### PR DESCRIPTION
### feat(recipe-detail): 레시피 상세 화면 구현, 조리시작 버튼 및 뷰모델 로직 추가

- feat(recipe-detail): RecipeDetailScreen 화면 구현  
  - RecipeOverview, CookStepsCarousel을 조건부로 렌더링  
  - YoutubePlayer 연동 (react-native-youtube-iframe)

- feat(recipe-view-model): useRecipeDetailViewModel 훅 구현  
  - recipeId와 초기값(title, youtubeId)을 기반으로 뷰모델 상태 구성  
  - fetchRecipeDetail API 호출을 통해 상세 정보 갱신  
  - loading, error 상태 포함

- test(recipe-view-model): 뷰모델 유닛 테스트 작성  
  - API 성공/실패 케이스  
  - 초기값 없는 경우 API 응답 기반 title/youtubeId 설정 검증

- feat(recipe-domain): RecipeDetail 도메인 클래스 구현  
  - create, updateDetails, formatTime 메서드 포함

- test(recipe-domain): RecipeDetail 도메인 단위 테스트 작성  
  - formatTime 변환, 도메인 상태 업데이트 테스트 포함

- mock(recipe-api): recipeDetailApiMock 등 mock API 데이터 구성  
  - 테스트 및 개발 환경에서 실제 API 없이 활용 가능

---

### ✅ 체크리스트

- [x] 기능 테스트 완료  
- [x] 모든 테스트 통과 (`npm run test` or `jest`)  
- [x] 린트/포맷 확인 완료 (eslint, prettier)  

Closes #4 