### PR TITLE
feat(recipe-cook): 레시피 조리 단계 캐러셀 및 카드 컴포넌트 구현

### DIFF
--- a/__tests__/recipes/CookStep.test.ts
+++ b/__tests__/recipes/CookStep.test.ts
@@ -1,0 +1,24 @@
+import {CookStepApiResponse} from "@/src/features/recipe/api/recipe";
+import {CookStep} from "@/src/features/recipe/cook/types/CookStep";
+
+describe('CookStep 클래스는', () => {
+    describe('of 메소드는', () => {
+        it('주어진 API 응답을 기반으로 CookStep 인스턴스를 생성해야 한다', () => {
+            const apiResponse: CookStepApiResponse = {
+                stepId: 'step1',
+                index: 1,
+                description: '재료 준비하기',
+                startTime: 0,
+                endTime: 30,
+            };
+
+            const step = CookStep.of(apiResponse);
+
+            expect(step.stepId).toBe(apiResponse.stepId);
+            expect(step.index).toBe(apiResponse.index);
+            expect(step.description).toBe(apiResponse.description);
+            expect(step.startTime).toBe(apiResponse.startTime);
+            expect(step.endTime).toBe(apiResponse.endTime);
+        });
+    })
+})

--- a/__tests__/recipes/RecipeDetail.test.ts
+++ b/__tests__/recipes/RecipeDetail.test.ts
@@ -1,0 +1,74 @@
+import { RecipeDetail } from '@/src/features/recipe/types/RecipeDetail';
+import {recipeDetailApiMock} from '@/src/features/recipe/__mocks__/fetchRecipe.mock';
+
+describe('RecipeDetail 클래스를 사용 할때', () => {
+
+    const defaultParams = {
+        initialRecipeId: 'success-id',
+        initialTitle: '초기 제목',
+        initialYoutubeId: 'initial-yt-id',
+    };
+
+    describe('formatTime 메서드는', () => {
+        it.each([
+            [0, '준비 시간 없음'],
+            [-5, '준비 시간 없음'],
+            [10, '10분'],
+            [60, '1시간'],
+            [75, '1시간 15분'],
+            [120, '2시간'],
+        ])('총 소요시간이 %i분일 때 "%s"을(를) 반환해야 한다', (input, expected) => {
+            expect(RecipeDetail.formatTime(input)).toBe(expected);
+        });
+    });
+
+    describe('create 메서드는', () => {
+        it('초기 값들을 갖는 RecipeDetail 인스턴스를 생성해야 한다', () => {
+            const recipe = RecipeDetail.create(defaultParams.initialRecipeId, defaultParams.initialTitle, defaultParams.initialYoutubeId);
+
+            expect(recipe.recipeId).toBe(defaultParams.initialRecipeId);
+            expect(recipe.title).toBe(defaultParams.initialTitle);
+            expect(recipe.youtubeId).toBe(defaultParams.initialYoutubeId);
+            expect(recipe.summary).toBe('');
+            expect(recipe.totalTime).toBe('');
+            expect(recipe.ingredients).toEqual([]);
+            expect(recipe.steps).toEqual([]);
+        });
+
+        it('title과 youtubeId가 없으면 빈 문자열로 설정되어야 한다', () => {
+            const recipe = RecipeDetail.create(defaultParams.initialRecipeId);
+
+            expect(recipe.title).toBe('');
+            expect(recipe.youtubeId).toBe('');
+        });
+    });
+
+    describe('updateDetails 메서드는', () => {
+        it('API 응답 값을 기반으로 새로운 RecipeDetail 인스턴스를 반환해야 한다', () => {
+            const initial = RecipeDetail.create(defaultParams.initialRecipeId, defaultParams.initialTitle, defaultParams.initialYoutubeId);
+
+            const updated = initial.updateDetails(recipeDetailApiMock);
+
+
+            expect(updated.recipeId).toBe(defaultParams.initialRecipeId);
+            expect(updated.title).toBe(recipeDetailApiMock.title);
+            expect(updated.youtubeId).toBe(recipeDetailApiMock.youtubeId);
+            expect(updated.summary).toBe(recipeDetailApiMock.summary);
+            expect(updated.totalTime).toBe(RecipeDetail.formatTime(recipeDetailApiMock.totalTime));
+            expect(updated.ingredients).toEqual(recipeDetailApiMock.ingredients);
+            updated.steps.forEach(
+                (step, index) => {
+                    const apiStep = recipeDetailApiMock.steps[index];
+                    expect(step.stepId).toBe(apiStep.stepId);
+                }
+            )
+        });
+
+        it('기존 인스턴스와는 다른 객체를 반환해야 한다', () => {
+            const recipe = RecipeDetail.create(defaultParams.initialRecipeId, defaultParams.initialTitle, defaultParams.initialYoutubeId);
+            const updated = recipe.updateDetails(recipeDetailApiMock);
+
+            expect(updated).not.toBe(recipe);
+        });
+    });
+});

--- a/app.json
+++ b/app.json
@@ -36,7 +36,8 @@
       ]
     ],
     "experiments": {
-      "typedRoutes": true
+      "typedRoutes": true,
+      "reactCanary": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,11 +31,12 @@
         "expo-web-browser": "~14.1.6",
         "jest": "~29.7.0",
         "jest-expo": "~53.0.7",
-        "react": "19.0.0",
-        "react-dom": "19.0.0",
+        "react": "19.1.0",
+        "react-dom": "19.1.0",
         "react-native": "0.79.3",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-reanimated": "~3.17.4",
+        "react-native-reanimated-carousel": "^4.0.2",
         "react-native-reanimated-skeleton": "^1.6.0",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
@@ -47,7 +48,7 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@testing-library/react-native": "^13.2.0",
-        "@types/react": "~19.0.10",
+        "@types/react": "~19.1.0",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~9.2.0",
         "typescript": "~5.8.3"
@@ -3908,11 +3909,10 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.0.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.14.tgz",
-      "integrity": "sha512-ixLZ7zG7j1fM0DijL9hDArwhwcCb4vqmePgwtV0GfnkHRSCUEv4LvzarcTdhoqgyMznUx/EhoTUv31CKZzkQlw==",
+      "version": "19.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.7.tgz",
+      "integrity": "sha512-BnsPLV43ddr05N71gaGzyZ5hzkCmGwhMvYc8zmvI8Ci1bRkkDSzDDVfAXfN2tk748OwI7ediiPX6PfT9p0QGVg==",
       "devOptional": true,
-      "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -13068,10 +13068,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
-      "license": "MIT",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13108,16 +13107,20 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
-      "license": "MIT",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "dependencies": {
-        "scheduler": "^0.25.0"
+        "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^19.0.0"
+        "react": "^19.1.0"
       }
+    },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="
     },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
@@ -13271,6 +13274,17 @@
         "@babel/core": "^7.0.0-0",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-reanimated-carousel": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated-carousel/-/react-native-reanimated-carousel-4.0.2.tgz",
+      "integrity": "sha512-vNpCfPlFoOVKHd+oB7B0luoJswp+nyz0NdJD8+LCrf25JiNQXfM22RSJhLaksBHqk3fm8R4fKWPNcfy5w7wL1Q==",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-native": ">=0.70.3",
+        "react-native-gesture-handler": ">=2.9.0",
+        "react-native-reanimated": ">=3.0.0"
       }
     },
     "node_modules/react-native-reanimated-skeleton": {

--- a/package.json
+++ b/package.json
@@ -35,11 +35,12 @@
     "expo-web-browser": "~14.1.6",
     "jest": "~29.7.0",
     "jest-expo": "~53.0.7",
-    "react": "19.0.0",
-    "react-dom": "19.0.0",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
     "react-native": "0.79.3",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-reanimated": "~3.17.4",
+    "react-native-reanimated-carousel": "^4.0.2",
     "react-native-reanimated-skeleton": "^1.6.0",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
@@ -51,7 +52,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@testing-library/react-native": "^13.2.0",
-    "@types/react": "~19.0.10",
+    "@types/react": "~19.1.0",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
     "typescript": "~5.8.3"

--- a/src/features/recipe/__mocks__/fetchRecipe.mock.ts
+++ b/src/features/recipe/__mocks__/fetchRecipe.mock.ts
@@ -1,0 +1,70 @@
+import {RecipeSummary} from "@/src/features/recipe/types/RecipeSummary";
+import {RecipeDetailApiResponse, RecipeSummaryApiResponse} from "@/src/features/recipe/api/recipe";
+
+export const recipeDetailApiMock: RecipeDetailApiResponse = {
+    title: '백종원의 제육볶음',
+    summary: '매콤달콤한 양념으로 밥도둑 제육볶음을 완성해보세요.',
+    ingredients: [
+        '돼지고기 앞다리살',
+        '양파',
+        '대파',
+        '고추장',
+        '고춧가루',
+        '간장',
+        '설탕',
+        '다진 마늘',
+        '참기름',
+        '후추'
+    ],
+    steps: [
+        {
+            stepId: 'step1-Id',
+            index: 1,
+            description: '돼지고기를 먹기 좋은 크기로 썬다.',
+            startTime: 0,
+            endTime: 5
+        },
+        {
+            stepId: 'step2-Id',
+            index: 2,
+            description: '양파와 대파를 채 썬다.',
+            startTime: 5,
+            endTime: 10
+        },
+        {
+            stepId: 'step3-Id',
+            index: 3,
+            description: '양념장을 만들어 재료와 섞는다.',
+            startTime: 10,
+            endTime: 15
+        },
+        {
+            stepId: 'step4-Id',
+            index: 4,
+            description: '팬에 재료를 볶아 완성한다.',
+            startTime: 15,
+            endTime: 25
+        }
+    ],
+    totalTime: 25,
+    youtubeId: 'j7s9VRsrm9o'
+};
+
+export const recipeSummariesApiMock: Record<string, RecipeSummaryApiResponse> = {
+    '1': {
+        recipeId: '1',
+        title: '백종원의 제육볶음',
+        youtubeId: 'j7s9VRsrm9o',
+        count: 120,
+        createdAt: '2023-10-01T12:00:00Z'
+    },
+    '2': {
+        recipeId: '2',
+        title: '백종원의 제육볶음',
+        youtubeId: 'j7s9VRsrm9o',
+        count: 120,
+        createdAt: '2023-10-01T12:00:00Z'
+    }
+}
+
+export const recipeSummariesMock: RecipeSummary[] = Object.values(recipeSummariesApiMock).map(apiResponse => RecipeSummary.create(apiResponse));

--- a/src/features/recipe/components/RecipeOverview.tsx
+++ b/src/features/recipe/components/RecipeOverview.tsx
@@ -1,0 +1,62 @@
+import { RecipeDetail } from '@/src/features/recipe/types/RecipeDetail';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import React from 'react';
+
+type Props = {
+    recipe: RecipeDetail;
+    onStart: () => void;
+};
+
+export function RecipeOverview({ recipe, onStart }: Props) {
+    return (
+        <View style={styles.wrapper}>
+            <ScrollView contentContainerStyle={styles.container}>
+                <View style={styles.detail}>
+                    <Text style={styles.title}>{recipe.title}</Text>
+                    <Text style={styles.summary}>{recipe.summary}</Text>
+
+                    <Text style={styles.sectionTitle}>소요 시간</Text>
+                    <Text style={styles.content}>{recipe.totalTime}</Text>
+
+                    <Text style={styles.sectionTitle}>재료</Text>
+                    {recipe.ingredients.map((item, index) => (
+                        <Text key={index} style={styles.content}>
+                            {index + 1}. {item}
+                        </Text>
+                    ))}
+
+                    <Text style={styles.sectionTitle}>조리 단계</Text>
+                    {recipe.steps.map((step, index) => (
+                        <Text key={index} style={styles.content}>
+                            {index + 1}. {step.description}
+                        </Text>
+                    ))}
+                </View>
+            </ScrollView>
+
+            <Pressable style={styles.startButton} onPress={onStart}>
+                <Text style={styles.startButtonText}>조리 시작하기</Text>
+            </Pressable>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    wrapper: { flex: 1, backgroundColor: '#fff' },
+    container: { paddingBottom: 100 },
+    detail: { padding: 20 },
+    startButton: {
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        backgroundColor: '#f33',
+        paddingVertical: 18,
+        alignItems: 'center',
+    },
+    startButtonText: { color: '#fff', fontWeight: 'bold', fontSize: 16 },
+    title: { fontSize: 24, fontWeight: 'bold', marginBottom: 12 },
+    summary: { fontSize: 16, marginBottom: 20 },
+    sectionTitle: { fontSize: 18, fontWeight: '600', marginTop: 16, marginBottom: 6 },
+    content: { fontSize: 15, marginBottom: 4 },
+});

--- a/src/features/recipe/components/RecipeVideo.tsx
+++ b/src/features/recipe/components/RecipeVideo.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import YoutubePlayer, {YoutubeIframeRef} from 'react-native-youtube-iframe';
+
+type Props = {
+    ref : React.Ref<YoutubeIframeRef | null>;
+    videoId: string;
+};
+
+export function RecipeVideo({ videoId, ref }: Props) {
+    return (
+        <YoutubePlayer height={230} ref={ref} play={true} videoId={videoId} />
+    );
+}

--- a/src/features/recipe/cook/components/CookStepCard.tsx
+++ b/src/features/recipe/cook/components/CookStepCard.tsx
@@ -1,0 +1,65 @@
+import Animated, {interpolate, SharedValue, useAnimatedStyle} from "react-native-reanimated";
+import React from "react";
+import {StyleSheet, Text, View} from "react-native";
+import {CookStep} from "@/src/features/recipe/cook/types/CookStep";
+
+interface Props {
+    item: CookStep;
+    animationValue: SharedValue<number>;
+}
+
+export function CookStepCard({ item, animationValue }: Props) {
+
+    const LIGHT_GRAY = "#4A4A4A";
+
+    const overlayStyle = useAnimatedStyle(() => {
+        const opacity = interpolate(animationValue.value, [-1, 0, 1], [0.6, 0, 0.6]);
+        return { backgroundColor: LIGHT_GRAY, opacity };
+    });
+
+    return (
+        <View style={styles.cardWrapper}>
+            <View style={styles.page}>
+                <Text style={styles.stepTitle}>Step {item.index}</Text>
+                <Text style={styles.stepDescription}>{item.description}</Text>
+            </View>
+            <Animated.View
+                pointerEvents="none"
+                style={[styles.overlayFill, overlayStyle]}
+            />
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    cardWrapper: {
+        flex: 1,
+        overflow: 'hidden',
+        justifyContent: 'center',
+        alignItems: 'center',
+        borderRadius: 10,
+    },
+
+    page: {
+        flex: 1,
+        width: '100%',
+        backgroundColor: '#F2F2F2',
+        borderRadius: 12,
+        justifyContent: 'center',
+        alignItems: 'center',
+        paddingHorizontal: 16,
+    },
+
+    stepTitle: {
+        fontSize: 24,
+        fontWeight: 'bold',
+        marginBottom: 10,
+    },
+
+    stepDescription: {
+        fontSize: 18,
+        textAlign: 'center',
+    },
+
+    overlayFill: StyleSheet.absoluteFillObject,
+});

--- a/src/features/recipe/cook/components/CookStepsCarousel.tsx
+++ b/src/features/recipe/cook/components/CookStepsCarousel.tsx
@@ -1,0 +1,74 @@
+import {Dimensions, StyleSheet, View} from "react-native";
+import Carousel from "react-native-reanimated-carousel";
+import {CookStepCard} from "@/src/features/recipe/cook/components/CookStepCard";
+import React, {useEffect, useState} from "react";
+import {YoutubeIframeRef} from "react-native-youtube-iframe";
+import {RecipeDetail} from "@/src/features/recipe/types/RecipeDetail";
+
+const { width: screenWidth } = Dimensions.get("window");
+
+interface Props {
+    recipe: RecipeDetail;
+    playerRef: React.RefObject<YoutubeIframeRef | null>;
+    onExit: () => void;
+}
+
+export function CookStepsCarousel({ recipe, playerRef, onExit }: Props) {
+    const recipeSteps = recipe.steps
+    const [currentStepIndex, setCurrentStepIndex] = useState(0);
+
+    const currentStep = recipeSteps[currentStepIndex];
+
+    useEffect(() => {
+        const interval = setInterval(async () => {
+            try {
+                const elapsedSec = await playerRef.current?.getCurrentTime?.() ?? 0;
+                if (currentStep.startTime > elapsedSec || currentStep.endTime <= elapsedSec) {
+                    playerRef.current?.seekTo(currentStep.startTime, true);
+                }
+            } catch (e) {
+                console.error("Error getting current time:", e);
+            }
+        }, 500);
+
+        return () => clearInterval(interval);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [currentStep]);
+
+    return (
+        <View style={styles.wrapper}>
+            <Carousel
+                width={screenWidth}
+                height={500}
+                data={recipeSteps}
+                mode="parallax"
+                modeConfig={{
+                    parallaxScrollingScale: 0.85,
+                    parallaxScrollingOffset: 80,
+                }}
+                loop={false}
+                overscrollEnabled={false}
+                scrollAnimationDuration={600}
+                snapEnabled={true}
+                onSnapToItem={(index) => {
+                    setCurrentStepIndex(index);
+                    const step = recipeSteps[index];
+                    playerRef.current?.seekTo(step.startTime, true);
+                }}
+                renderItem={({ item, animationValue }) => {
+                    return (
+                        <CookStepCard
+                            key={item.stepId}
+                            item = {item}
+                            animationValue={animationValue}
+                        />
+                    );
+                }}
+            />
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    wrapper: {flex: 1, backgroundColor: "#fff"},
+});

--- a/src/features/recipe/cook/components/CookStepsCarousel.tsx
+++ b/src/features/recipe/cook/components/CookStepsCarousel.tsx
@@ -67,7 +67,7 @@ export function CookStepsCarousel({ recipe, playerRef, onExit }: Props) {
             />
         </View>
     );
-};
+}
 
 const styles = StyleSheet.create({
     wrapper: {flex: 1, backgroundColor: "#fff"},

--- a/src/features/recipe/cook/types/CookStep.ts
+++ b/src/features/recipe/cook/types/CookStep.ts
@@ -1,0 +1,35 @@
+import {CookStepApiResponse} from "@/src/features/recipe/api/recipe";
+
+export class CookStep {
+    stepId: string;
+    index: number;
+    description: string;
+    startTime: number;
+    endTime: number;
+
+    private constructor(
+        stepId: string,
+        index: number,
+        description: string,
+        startTime: number,
+        endTime: number
+    ) {
+        this.stepId = stepId;
+        this.description = description;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.index = index;
+    }
+
+    static of(
+        apiResponse: CookStepApiResponse
+    ):CookStep{
+        return new CookStep(
+            apiResponse.stepId,
+            apiResponse.index,
+            apiResponse.description,
+            apiResponse.startTime,
+            apiResponse.endTime
+        );
+    }
+}

--- a/src/features/recipe/types/RecipeDetail.ts
+++ b/src/features/recipe/types/RecipeDetail.ts
@@ -1,0 +1,69 @@
+import {RecipeDetailApiResponse} from "@/src/features/recipe/api/recipe";
+import {CookStep} from "@/src/features/recipe/cook/types/CookStep";
+
+export class RecipeDetail {
+    recipeId: string;
+    title: string;
+    youtubeId: string;
+    summary: string;
+    totalTime: string;
+    ingredients: string[];
+    steps: CookStep[];
+
+    private constructor(
+        recipeId: string,
+        title: string,
+        youtubeId: string,
+        summary: string,
+        totalTime: string,
+        ingredients: string[],
+        steps: CookStep[]
+    ) {
+        this.recipeId = recipeId;
+        this.title = title;
+        this.youtubeId = youtubeId;
+        this.summary = summary;
+        this.totalTime = totalTime;
+        this.ingredients = ingredients;
+        this.steps = steps
+    }
+
+    static create(
+        recipeId: string,
+        title?: string,
+        youtubeId?: string
+    ): RecipeDetail {
+        return new RecipeDetail(recipeId, title ?? '', youtubeId ?? '', '', '', [], []);
+    }
+
+    updateDetails(
+        apiResponse: RecipeDetailApiResponse
+    ): RecipeDetail {
+        return new RecipeDetail(
+            this.recipeId,
+            apiResponse.title,
+            apiResponse.youtubeId,
+            apiResponse.summary,
+            RecipeDetail.formatTime(apiResponse.totalTime),
+            apiResponse.ingredients,
+            apiResponse.steps.map(step => CookStep.of(step))
+        );
+    }
+
+    static formatTime(totalTime: number): string {
+        if (totalTime <= 0) {
+            return '준비 시간 없음';
+        }
+
+        const hours = Math.floor(totalTime / 60);
+        const minutes = totalTime % 60;
+
+        if (hours > 0 && minutes > 0) {
+            return `${hours}시간 ${minutes}분`;
+        } else if (hours > 0) {
+            return `${hours}시간`;
+        } else {
+            return `${minutes}분`;
+        }
+    }
+}

--- a/src/features/recipe/types/RecipeMode.ts
+++ b/src/features/recipe/types/RecipeMode.ts
@@ -1,0 +1,4 @@
+export enum RecipeMode {
+    Detail = 'detail',
+    Cook = 'cook',
+}

--- a/src/features/recipe/viewmodels/useRecipeDetailViewModel.ts
+++ b/src/features/recipe/viewmodels/useRecipeDetailViewModel.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { RecipeDetail } from '@/src/features/recipe/types/RecipeDetail';
+import { fetchRecipeDetail } from '@/src/features/recipe/api/recipe';
+
+
+export function useRecipeDetailViewModel(
+    recipeId: string,
+    initialYoutubeId?: string,
+    initialTitle?: string
+): {
+    recipe: RecipeDetail;
+    loading: boolean;
+    error: Error | null;
+} {
+    const [recipe, setRecipe] = useState<RecipeDetail>(
+        RecipeDetail.create(recipeId, initialTitle, initialYoutubeId)
+    );
+
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<Error | null>(null);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const data = await fetchRecipeDetail(recipeId);
+                setRecipe(prev => prev.updateDetails(data));
+            } catch (err) {
+                setError(err as Error);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        void fetchData();
+    },  [recipeId, initialTitle, initialYoutubeId]);
+
+    return { recipe, loading, error };
+}


### PR DESCRIPTION
feat(recipe-cook): 레시피 조리 단계 캐러셀 및 카드 컴포넌트 구현

### feat(recipe-cook): CookStepsCarousel 컴포넌트 구현
- react-native-reanimated-carousel 기반의 캐러셀 구현
- 캐러셀 Snap 시 유튜브 플레이어 위치 이동 기능 포함
- 현재 스텝과 영상 구간 동기화 (setInterval 주기적 체크)

### feat(recipe-cook): CookStepCard 컴포넌트 구현
- 조리 단계(index, 설명)를 표시하는 카드 UI 구성
- Reanimated 기반 페이드 오버레이 애니메이션 적용

### feat(recipe-domain): CookStep 도메인 모델 클래스 추가
- of 메서드를 통한 API 응답 → 도메인 객체 변환 지원

### test(recipe-domain): CookStep 도메인 유닛 테스트 작성
- of 메서드 정상 동작 검증
- 각 필드가 정확히 매핑되는지 확인

### chore(expo): 패키지 및 Expo 설정 업데이트
- react-native-reanimated-carousel 라이브러리 추가
- app.json에서 reactCanary 실험 기능 활성화

주요 추가 패키지:
- react-native-reanimated-carousel

---

### ✅ 체크리스트

- [x] 기능 테스트 완료  
- [x] 모든 테스트 통과 (`npm run test` or `jest`)  
- [x] 린트/포맷 확인 완료 (eslint, prettier)  

Closes #3 
