### PR TITLE
chore: API 정리 + type 컨벤션 + 테마 순서 변경

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,47 @@ const res = await client.get('/recipes');
 const res = await client.post('/account/login/oauth', data, { skipAuth: true });
 ```
 
+## TypeScript 타입 선언 ⭐
+
+**객체 shape은 항상 `type`. `interface` 금지.**
+
+```ts
+// ❌ 나쁨
+export interface Recipe {
+  id: string;
+  title: string;
+}
+
+// ✅ 좋음
+export type Recipe = {
+  id: string;
+  title: string;
+};
+```
+
+확장은 intersection으로:
+
+```ts
+// ❌ 나쁨
+interface PressableCardProps extends PressableProps {
+  variant: 'primary' | 'secondary';
+}
+
+// ✅ 좋음
+type PressableCardProps = PressableProps & {
+  variant: 'primary' | 'secondary';
+};
+```
+
+### 이유
+- 같은 이름의 `interface`는 자동 **선언 병합(declaration merging)** → 모르게 누가 끼워넣어도 에러 안 남, 위험
+- `type`은 union/intersection/매핑/조건부 등 표현력이 더 넓고 일관됨
+- 같은 이름 두 번 선언 시 즉시 에러로 잡힘
+
+### 예외 (이때만 `interface` 허용)
+1. 외부 라이브러리 타입 augment (`declare module ...`)
+2. 클래스가 `implements` 해야 하고 선언 병합이 진짜로 필요한 경우
+
 ## 컴포넌트 작성
 
 - **inline style 사용** (StyleSheet 거의 안 씀)
@@ -251,6 +292,7 @@ const res = await client.post('/account/login/oauth', data, { skipAuth: true });
 - ❌ entities 내부 파일 직접 import (반드시 barrel 경유)
 - ❌ shared가 entities/pages를 import
 - ❌ 이모지를 UI 텍스트로 사용
+- ❌ `interface` 사용 (예외: 라이브러리 augment, 클래스 implements + 병합 필요)
 
 ## 새 기능 추가 시 체크리스트
 

--- a/assets/data/themes.json
+++ b/assets/data/themes.json
@@ -82,8 +82,7 @@
           "is_curator_pick": true,
           "category": "boyfriend",
           "dish_name": "소고기 덮밥",
-          "recipe_id": "00ae3c64-e77e-473a-b4fc-e9133a877353",
-          "failed": true
+          "recipe_id": "00ae3c64-e77e-473a-b4fc-e9133a877353"
         },
         {
           "id": "love-boyfriend-3",
@@ -121,8 +120,7 @@
           "is_curator_pick": true,
           "category": "boyfriend",
           "dish_name": "중화 비빔당면",
-          "recipe_id": "da51f3d2-3a4c-48ca-84a0-1f19d73f8a7a",
-          "failed": true
+          "recipe_id": "da51f3d2-3a4c-48ca-84a0-1f19d73f8a7a"
         },
         {
           "id": "love-boyfriend-4",
@@ -159,8 +157,7 @@
           "is_curator_pick": true,
           "category": "boyfriend",
           "dish_name": "부대찌개",
-          "recipe_id": "b5015637-4cb5-49d5-a365-dde8ba9d4a14",
-          "failed": true
+          "recipe_id": "b5015637-4cb5-49d5-a365-dde8ba9d4a14"
         },
         {
           "id": "love-boyfriend-5",
@@ -199,8 +196,7 @@
           "is_curator_pick": true,
           "category": "boyfriend",
           "dish_name": "스테이크 덮밥",
-          "recipe_id": "3cac6b4c-8f71-4234-b9df-99ddbefce9fc",
-          "failed": true
+          "recipe_id": "3cac6b4c-8f71-4234-b9df-99ddbefce9fc"
         },
         {
           "id": "love-boyfriend-6",
@@ -307,8 +303,7 @@
           "is_curator_pick": true,
           "category": "girlfriend",
           "dish_name": "프렌치 토스트",
-          "recipe_id": "c976e1ad-8a4e-4d76-9421-b396796dd370",
-          "failed": true
+          "recipe_id": "c976e1ad-8a4e-4d76-9421-b396796dd370"
         },
         {
           "id": "love-girlfriend-3",
@@ -343,8 +338,7 @@
           "is_curator_pick": true,
           "category": "girlfriend",
           "dish_name": "버터 감바스",
-          "recipe_id": "60b21e77-0cc7-46f3-a9f6-3e65ba596248",
-          "failed": true
+          "recipe_id": "60b21e77-0cc7-46f3-a9f6-3e65ba596248"
         },
         {
           "id": "love-girlfriend-4",
@@ -379,8 +373,7 @@
           "is_curator_pick": true,
           "category": "girlfriend",
           "dish_name": "크리미 오므라이스",
-          "recipe_id": "d7817dc2-4914-4418-a26c-d7f124efc714",
-          "failed": true
+          "recipe_id": "d7817dc2-4914-4418-a26c-d7f124efc714"
         },
         {
           "id": "love-girlfriend-5",
@@ -449,8 +442,7 @@
           "is_curator_pick": true,
           "category": "girlfriend",
           "dish_name": "폭신 팬케이크",
-          "recipe_id": "9ae11781-1cd0-4909-806c-8823b7e58ccd",
-          "failed": true
+          "recipe_id": "9ae11781-1cd0-4909-806c-8823b7e58ccd"
         },
         {
           "id": "love-girlfriend-7",
@@ -484,8 +476,7 @@
           "is_curator_pick": true,
           "category": "girlfriend",
           "dish_name": "참간초 파스타",
-          "recipe_id": "6f15d2c0-104a-44e1-be5b-2b4875b03cba",
-          "failed": true
+          "recipe_id": "6f15d2c0-104a-44e1-be5b-2b4875b03cba"
         },
         {
           "id": "love-first-date-1",
@@ -518,8 +509,7 @@
           "is_curator_pick": true,
           "category": "first-date",
           "dish_name": "알리오올리오",
-          "recipe_id": "73e6683a-fce3-46ac-9155-9941b6653190",
-          "failed": true
+          "recipe_id": "73e6683a-fce3-46ac-9155-9941b6653190"
         },
         {
           "id": "love-first-date-2",
@@ -654,8 +644,7 @@
           "is_curator_pick": true,
           "category": "first-date",
           "dish_name": "감바스",
-          "recipe_id": "3f555dfc-16fb-40df-8fca-3adcb57ed98c",
-          "failed": true
+          "recipe_id": "3f555dfc-16fb-40df-8fca-3adcb57ed98c"
         },
         {
           "id": "love-home-invite-1",
@@ -722,8 +711,7 @@
           "is_curator_pick": true,
           "category": "home-invite",
           "dish_name": "스테이크",
-          "recipe_id": "70b7db1b-25d5-4b9c-a705-a4980552ac19",
-          "failed": true
+          "recipe_id": "70b7db1b-25d5-4b9c-a705-a4980552ac19"
         },
         {
           "id": "love-home-invite-3",
@@ -756,8 +744,7 @@
           "is_curator_pick": false,
           "category": "home-invite",
           "dish_name": "크림 감자 뇨끼",
-          "recipe_id": "36c98ed8-8025-4ffe-bc40-a2c9bca3db90",
-          "failed": true
+          "recipe_id": "36c98ed8-8025-4ffe-bc40-a2c9bca3db90"
         },
         {
           "id": "love-home-invite-4",
@@ -790,8 +777,7 @@
           "is_curator_pick": false,
           "category": "home-invite",
           "dish_name": "찹스테이크",
-          "recipe_id": "bbc4e9e9-9eb1-411b-b916-4b31f5132f68",
-          "failed": true
+          "recipe_id": "bbc4e9e9-9eb1-411b-b916-4b31f5132f68"
         },
         {
           "id": "love-home-invite-5",
@@ -857,8 +843,7 @@
           "is_curator_pick": false,
           "category": "home-invite",
           "dish_name": "라따뚜이",
-          "recipe_id": "0848ffa7-7cd8-4e9d-bab1-bad382c2d6a2",
-          "failed": true
+          "recipe_id": "0848ffa7-7cd8-4e9d-bab1-bad382c2d6a2"
         },
         {
           "id": "love-cook-together-1",
@@ -891,8 +876,7 @@
           "is_curator_pick": true,
           "category": "cook-together",
           "dish_name": "고기만두",
-          "recipe_id": "3de171b2-6a1e-4630-ab51-89bfb93ad208",
-          "failed": true
+          "recipe_id": "3de171b2-6a1e-4630-ab51-89bfb93ad208"
         },
         {
           "id": "love-cook-together-2",
@@ -925,8 +909,7 @@
           "is_curator_pick": true,
           "category": "cook-together",
           "dish_name": "김밥",
-          "recipe_id": "5b769f33-da96-4a22-9bb7-89c8164c2a17",
-          "failed": true
+          "recipe_id": "5b769f33-da96-4a22-9bb7-89c8164c2a17"
         },
         {
           "id": "love-cook-together-3",
@@ -959,8 +942,7 @@
           "is_curator_pick": true,
           "category": "cook-together",
           "dish_name": "수제 버거",
-          "recipe_id": "5b5ec22a-92cb-496e-aa4e-d26f1a250a78",
-          "failed": true
+          "recipe_id": "5b5ec22a-92cb-496e-aa4e-d26f1a250a78"
         },
         {
           "id": "love-cook-together-4",
@@ -993,8 +975,7 @@
           "is_curator_pick": false,
           "category": "cook-together",
           "dish_name": "초콜릿 딤섬",
-          "recipe_id": "bc61db78-4441-4898-983a-2cc9d558bbed",
-          "failed": true
+          "recipe_id": "bc61db78-4441-4898-983a-2cc9d558bbed"
         },
         {
           "id": "love-cook-together-5",
@@ -1061,8 +1042,7 @@
           "is_curator_pick": false,
           "category": "cook-together",
           "dish_name": "곰돌이 마카롱",
-          "recipe_id": "a4100840-32dc-41ed-8f14-65dcf0a8a20f",
-          "failed": true
+          "recipe_id": "a4100840-32dc-41ed-8f14-65dcf0a8a20f"
         },
         {
           "id": "love-cook-together-7",
@@ -1095,8 +1075,7 @@
           "is_curator_pick": false,
           "category": "cook-together",
           "dish_name": "먹물 피자",
-          "recipe_id": "e104fa31-813e-4d67-a140-2db772b5d079",
-          "failed": true
+          "recipe_id": "e104fa31-813e-4d67-a140-2db772b5d079"
         },
         {
           "id": "love-lunchbox-1",
@@ -1129,8 +1108,7 @@
           "is_curator_pick": true,
           "category": "lunchbox",
           "dish_name": "소불고기",
-          "recipe_id": "7ad0976c-0a65-4448-b7fa-96e523a8b651",
-          "failed": true
+          "recipe_id": "7ad0976c-0a65-4448-b7fa-96e523a8b651"
         },
         {
           "id": "love-lunchbox-2",
@@ -1163,8 +1141,7 @@
           "is_curator_pick": true,
           "category": "lunchbox",
           "dish_name": "스팸주먹밥",
-          "recipe_id": "4d49559c-e9ce-4acd-925f-4359f67ef30c",
-          "failed": true
+          "recipe_id": "4d49559c-e9ce-4acd-925f-4359f67ef30c"
         },
         {
           "id": "love-lunchbox-3",
@@ -1231,8 +1208,7 @@
           "is_curator_pick": false,
           "category": "lunchbox",
           "dish_name": "3분 계란말이",
-          "recipe_id": "c1a3ef29-f0e9-4db2-bbcb-56aa2cd3f39b",
-          "failed": true
+          "recipe_id": "c1a3ef29-f0e9-4db2-bbcb-56aa2cd3f39b"
         },
         {
           "id": "love-lunchbox-5",
@@ -1265,8 +1241,7 @@
           "is_curator_pick": false,
           "category": "lunchbox",
           "dish_name": "옛날도시락",
-          "recipe_id": "d2ae61e5-c1f1-4da9-a1a6-0966e95534b2",
-          "failed": true
+          "recipe_id": "d2ae61e5-c1f1-4da9-a1a6-0966e95534b2"
         },
         {
           "id": "love-lunchbox-6",
@@ -1333,8 +1308,7 @@
           "is_curator_pick": false,
           "category": "lunchbox",
           "dish_name": "황태채무침",
-          "recipe_id": "44d92a0c-12b4-4367-9ce2-13c881a22c98",
-          "failed": true
+          "recipe_id": "44d92a0c-12b4-4367-9ce2-13c881a22c98"
         }
       ],
       "categories": [
@@ -1373,6 +1347,905 @@
           "name": "출근 도시락",
           "emoji": "🍱",
           "concept": "남친이 출근할 때 챙겨주는 도시락. 전날 밤 준비 가능, 보온/식어도 맛있음, 색감 균형, 새벽에 빨리 만들 수 있는 메뉴."
+        }
+      ]
+    },
+    {
+      "id": "night-snack",
+      "title": "밤에 땡기는",
+      "subtitle": "오늘 밤, 천사도 악마도 만족시키는 야식",
+      "color": "#6A4C93",
+      "mode": "dark",
+      "curator_quote": "오늘 밤, 천사도 악마도 만족시키는 야식",
+      "dishes": [
+        {
+          "id": "night-snack-17",
+          "title": "3분 완성 '계란마요 토스트'",
+          "channel": "자취요리신",
+          "youtube_url": "https://www.youtube.com/watch?v=0kFqX_L9G7I",
+          "estimated_duration": "1분",
+          "tags": {
+            "mood": [
+              "이불 속",
+              "새벽 한 시"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "쇼츠",
+            "pairing": [
+              "논알콜"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "디저트"
+            ],
+            "ingredient_focus": [
+              "달걀"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "따뜻한 한 조각이 마음을 채워.",
+          "hook": "배고프다고? 3분이면 충분해!",
+          "category": "quick-3",
+          "dish_name": "마요계란토스트",
+          "recipe_id": "d487cea4-60c9-4b24-bff7-2ac7213e18d5",
+          "failed": true
+        },
+        {
+          "id": "night-snack-21",
+          "title": "5분 완성 '간장버터우동' 자취 야식",
+          "channel": "간단한 맛남",
+          "youtube_url": "https://www.youtube.com/watch?v=KkSiTh7wx5M",
+          "estimated_duration": "5분",
+          "tags": {
+            "mood": [
+              "새벽 한 시",
+              "이불 속"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "쇼츠",
+            "pairing": [
+              "없음"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "일식"
+            ],
+            "ingredient_focus": [
+              "면"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "짭조름한 풍미가 입안 가득 춤춘다.",
+          "hook": "5분 만에 면 요리를 해내다니!",
+          "category": "quick-3",
+          "dish_name": "우동버터간장",
+          "recipe_id": "15a94765-0569-442f-9a4d-d8c6448f3b2b",
+          "failed": true
+        },
+        {
+          "id": "night-snack-22",
+          "title": "백종원의 '콘치즈' 인생 안주 레시피",
+          "channel": "백종원 PAIK JONG WON",
+          "youtube_url": "https://www.youtube.com/watch?v=zS_o6psOt9g",
+          "estimated_duration": "8분",
+          "tags": {
+            "mood": [
+              "혼술 한 잔",
+              "주말 밤"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "롱폼",
+            "pairing": [
+              "맥주"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "퓨전"
+            ],
+            "ingredient_focus": [
+              "치즈"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "한 입에 톡 터지는 달콤 짭짤함.",
+          "hook": "치즈 폭포 속 옥수수! 이거지!",
+          "category": "quick-3",
+          "dish_name": "치즈듬뿍콘",
+          "recipe_id": "9d342932-277a-4a6c-b43b-3cab77f87395"
+        },
+        {
+          "id": "night-snack-23",
+          "title": "일주일 세 번 먹는 '버터 누룽지 치즈밥'",
+          "channel": "꾸니로그",
+          "youtube_url": "https://www.youtube.com/watch?v=5vRSQcUfAM8",
+          "estimated_duration": "5분",
+          "tags": {
+            "mood": [
+              "새벽 한 시",
+              "이불 속"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "쇼츠",
+            "pairing": [
+              "없음"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "한식"
+            ],
+            "ingredient_focus": [
+              "밥"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "딱 5분, 구수한 치즈 향에 위로받아.",
+          "hook": "식사? 야식? 바삭한 누룽지 치즈밥!",
+          "category": "quick-3",
+          "dish_name": "버터치즈누룽지",
+          "recipe_id": "27774a31-8207-41c3-bd5a-1bbf4612913e"
+        },
+        {
+          "id": "night-snack-24",
+          "title": "감칠맛 폭발 '새우젓 계란찜' 5분 야식",
+          "channel": "나의 작은 부엌",
+          "youtube_url": "https://www.youtube.com/watch?v=27MfMpvfAPw",
+          "estimated_duration": "3분",
+          "tags": {
+            "mood": [
+              "새벽 한 시",
+              "이불 속"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "쇼츠",
+            "pairing": [
+              "없음"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "한식"
+            ],
+            "ingredient_focus": [
+              "달걀"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "부드러운 한 입, 지친 나를 토닥여줘.",
+          "hook": "이 촉촉함, 무려 5분만에 완성?",
+          "category": "quick-3",
+          "dish_name": "새우젓계란찜",
+          "recipe_id": "31744922-2cea-49bd-a1f4-f4290533c583"
+        },
+        {
+          "id": "night-snack-25",
+          "title": "다이어트 중 떡볶이 땡길 때 '두부 떡볶이'",
+          "channel": "김미푸드",
+          "youtube_url": "https://www.youtube.com/watch?v=Vk73tNxwV6U",
+          "estimated_duration": "2분",
+          "tags": {
+            "mood": [
+              "새벽 한 시",
+              "이불 속"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "쇼츠",
+            "pairing": [
+              "없음"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "한식"
+            ],
+            "ingredient_focus": [
+              "떡"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "말랑한 두부로 맵달하게 즐기는 건강 간식",
+          "hook": "떡볶이 유혹, 더 이상 참지 마!",
+          "category": "guilt-free",
+          "dish_name": "두부 떡볶이",
+          "recipe_id": "b5a03ccf-bd08-4145-bb56-794183f6d01b",
+          "failed": true
+        },
+        {
+          "id": "night-snack-26",
+          "title": "감칠맛 폭발 '곤약면 비빔국수' 다이어트 야식",
+          "channel": "또먹",
+          "youtube_url": "https://www.youtube.com/watch?v=Hi-ikD3bLKU",
+          "estimated_duration": "3분",
+          "tags": {
+            "mood": [
+              "새벽 한 시",
+              "이불 속"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "숏폼",
+            "pairing": [
+              "없음"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "한식"
+            ],
+            "ingredient_focus": [
+              "면"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "탱글한 면발에 폭발하는 산뜻한 만족감",
+          "hook": "매콤새콤! 이 감칠맛은 못 참지",
+          "category": "guilt-free",
+          "dish_name": "곤약 비빔국수",
+          "recipe_id": "ecea9392-a33a-4aaa-a81b-3b0856eae1eb",
+          "failed": true
+        },
+        {
+          "id": "night-snack-27",
+          "title": "김신영 야식 '38kg 감량' 또띠아 케사디아",
+          "channel": "초이쿡",
+          "youtube_url": "https://www.youtube.com/watch?v=CZlwG_dVGJ4",
+          "estimated_duration": "2분",
+          "tags": {
+            "mood": [
+              "새벽 한 시",
+              "이불 속"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "쇼츠",
+            "pairing": [
+              "없음"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "퓨전"
+            ],
+            "ingredient_focus": [
+              "치즈"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "바삭 촉촉한데 건강까지 챙긴 치즈 간식",
+          "hook": "38kg 감량, 그 비법 간식이 여기?",
+          "category": "guilt-free",
+          "dish_name": "또띠아 케사디아",
+          "recipe_id": "071cab39-9943-461a-a2fa-abe58e75413e"
+        },
+        {
+          "id": "night-snack-28",
+          "title": "1분다이어터 '오트밀 한 그릇' 야식",
+          "channel": "1분다이어터 1mindiet",
+          "youtube_url": "https://www.youtube.com/watch?v=rzCYWhimwNs",
+          "estimated_duration": "1분",
+          "tags": {
+            "mood": [
+              "새벽 한 시",
+              "이불 속"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "쇼츠",
+            "pairing": [
+              "없음"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "한식"
+            ],
+            "ingredient_focus": [
+              "밥"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "빠르게 뚝딱 만들어 속 편하게 채우는 꿀조합",
+          "hook": "단 5분이면 나만의 건강 야식 완성!",
+          "category": "guilt-free",
+          "dish_name": "든든 오트밀",
+          "recipe_id": "9f448712-e26a-427b-ba52-3cae0691c884"
+        },
+        {
+          "id": "night-snack-29",
+          "title": "치즈 품은 '단호박 구이' 죄책감 ZERO 야식",
+          "channel": "워킹맘의 집밥",
+          "youtube_url": "https://www.youtube.com/watch?v=LtK32RnfgDA",
+          "estimated_duration": "10분",
+          "tags": {
+            "mood": [
+              "새벽 한 시",
+              "이불 속"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "쇼츠",
+            "pairing": [
+              "없음"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "퓨전"
+            ],
+            "ingredient_focus": [
+              "채소"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "달콤짭짤한 맛으로 하루의 피로를 녹이는 위로",
+          "hook": "달콤 촉촉한 단호박에 고소한 치즈가 쏙!",
+          "category": "guilt-free",
+          "dish_name": "치즈 단호박구이",
+          "recipe_id": "56710a02-b187-4c21-99bd-85c9aa9aeb25"
+        },
+        {
+          "id": "night-snack-30",
+          "title": "건두부 올린 '마라 짜파게티' 끝판왕",
+          "channel": "모루",
+          "youtube_url": "https://www.youtube.com/watch?v=4nZSgfgACWM",
+          "estimated_duration": "2분",
+          "tags": {
+            "mood": [
+              "새벽 한 시",
+              "이불 속"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "쇼츠",
+            "pairing": [
+              "맥주"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "퓨전"
+            ],
+            "ingredient_focus": [
+              "면"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "평범함에 더해지는 이국적인 매력.",
+          "hook": "이국적 향신료가 부르는 짜파게티의 변주",
+          "category": "ramen-mod",
+          "dish_name": "마라 짜파게티",
+          "recipe_id": "70e029ad-fc9d-48eb-b947-30062bd7cf41"
+        },
+        {
+          "id": "night-snack-31",
+          "title": "백종원의 '부대찌개맛 뿌햄라면' 꿀팁",
+          "channel": "백종원 PAIK JONG WON",
+          "youtube_url": "https://www.youtube.com/watch?v=qWI4b7BL2eA",
+          "estimated_duration": "3분",
+          "tags": {
+            "mood": [
+              "새벽 한 시",
+              "퇴근길"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "숏폼",
+            "pairing": [
+              "맥주"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "한식"
+            ],
+            "ingredient_focus": [
+              "면"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "끓이면 바로 든든한 한 끼.",
+          "hook": "이거야말로 라면의 진화!",
+          "category": "ramen-mod",
+          "dish_name": "부대찌개맛 라면",
+          "recipe_id": "6542412b-8b36-4834-96a0-ee8885fdb4d6"
+        },
+        {
+          "id": "night-snack-32",
+          "title": "치즈 폭탄 '까르보 불닭' 분식집 맛",
+          "channel": "FFAST FOOD",
+          "youtube_url": "https://www.youtube.com/watch?v=NXNIDr_glr8",
+          "estimated_duration": "5분",
+          "tags": {
+            "mood": [
+              "이불 속",
+              "혼술 한 잔"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "쇼츠",
+            "pairing": [
+              "맥주"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "퓨전"
+            ],
+            "ingredient_focus": [
+              "치즈"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "매운맛을 고소함으로 감싸다.",
+          "hook": "크림 소스처럼 꾸덕한 한 입?",
+          "category": "ramen-mod",
+          "dish_name": "까르보 불닭",
+          "recipe_id": "3076a022-d27e-4b50-a9b2-b68a35119fe0"
+        },
+        {
+          "id": "night-snack-33",
+          "title": "진짜 분식집 '떡라면' 끓이는 법",
+          "channel": "한끼대첩:간단한 요리 레시피",
+          "youtube_url": "https://www.youtube.com/watch?v=T289nNqfxt4",
+          "estimated_duration": "5분",
+          "tags": {
+            "mood": [
+              "새벽 한 시",
+              "이불 속"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "롱폼",
+            "pairing": [
+              "없음"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "한식"
+            ],
+            "ingredient_focus": [
+              "떡"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "추억의 맛이 그리울 때 딱.",
+          "hook": "집에서 이 맛을 재현한다고?",
+          "category": "ramen-mod",
+          "dish_name": "분식집 떡라면",
+          "recipe_id": "28d905b5-7fbd-4d32-828f-ac8ba94f8b4a"
+        },
+        {
+          "id": "night-snack-34",
+          "title": "성시경의 '극강 치즈 라면' 꾸덕 야식",
+          "channel": "모트리",
+          "youtube_url": "https://www.youtube.com/watch?v=nS6bs5hDB50",
+          "estimated_duration": "5분",
+          "tags": {
+            "mood": [
+              "혼술 한 잔",
+              "주말 밤"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "롱폼",
+            "pairing": [
+              "맥주"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "퓨전"
+            ],
+            "ingredient_focus": [
+              "치즈"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "입안 가득 채우는 깊은 고소함.",
+          "hook": "치즈 여섯 장은 넣어야 이 정도!",
+          "category": "ramen-mod",
+          "dish_name": "꾸덕 치즈 라면",
+          "recipe_id": "c066c80f-6d09-4a13-a46e-f7a12a04250f"
+        },
+        {
+          "id": "night-snack-35",
+          "title": "편의점 끝판왕 '마크정식' 6470원 야식",
+          "channel": "헬로푸드",
+          "youtube_url": "https://www.youtube.com/watch?v=S7P7m_zcf3s",
+          "estimated_duration": "3분",
+          "tags": {
+            "mood": [
+              "새벽 한 시",
+              "이불 속"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "숏폼",
+            "pairing": [
+              "맥주"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "퓨전"
+            ],
+            "ingredient_focus": [
+              "떡"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "모두가 인정하는 특별한 식사, 오늘 어때?",
+          "hook": "이게 바로 편의점 만찬의 정석!",
+          "category": "cvs-combo",
+          "dish_name": "마크정식",
+          "recipe_id": "a1edace1-0e76-4820-a258-033241179870"
+        },
+        {
+          "id": "night-snack-36",
+          "title": "겨울 필수 '오모리 김치찌개 컵라면' 꿀조합",
+          "channel": "20대 뭐 하지?",
+          "youtube_url": "https://www.youtube.com/watch?v=S7qaHSyz-kY",
+          "estimated_duration": "1분",
+          "tags": {
+            "mood": [
+              "새벽 한 시",
+              "혼술 한 잔"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "쇼츠",
+            "pairing": [
+              "소주"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "한식"
+            ],
+            "ingredient_focus": [
+              "면"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "그릇 가득 추위 녹이는 든든한 포만감.",
+          "hook": "싸늘한 날, 뜨끈한 위로가 필요하다면?",
+          "category": "cvs-combo",
+          "dish_name": "오모리 라면죽",
+          "recipe_id": "88ecc440-94f2-4bab-9aba-6c2a05d93751",
+          "failed": true
+        },
+        {
+          "id": "night-snack-37",
+          "title": "편의점 환상조합 '사리곰탕 만둣국' 1분 컷",
+          "channel": "라면아저씨 Ramyun Ahjussi",
+          "youtube_url": "https://www.youtube.com/watch?v=Tt9cA1Cj9hw",
+          "estimated_duration": "1분",
+          "tags": {
+            "mood": [
+              "새벽 한 시",
+              "이불 속"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "쇼츠",
+            "pairing": [
+              "없음"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "한식"
+            ],
+            "ingredient_focus": [
+              "면"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "놀랍도록 빠르게 완성되는 고급진 별미.",
+          "hook": "1분 만에 뚝딱! 이런 환상의 궁합 봤어?",
+          "category": "cvs-combo",
+          "dish_name": "사리곰탕 만둣국",
+          "recipe_id": "ff7b3062-1eec-4d5e-8f88-0cdc85d9bbd8"
+        },
+        {
+          "id": "night-snack-38",
+          "title": "삼각김밥으로 '불닭 치즈 리조또' 변신",
+          "channel": "직딩쿠킹",
+          "youtube_url": "https://www.youtube.com/watch?v=bIFPlKelCtI",
+          "estimated_duration": "5분",
+          "tags": {
+            "mood": [
+              "이불 속",
+              "혼술 한 잔"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "쇼츠",
+            "pairing": [
+              "맥주"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "퓨전"
+            ],
+            "ingredient_focus": [
+              "치즈"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "흔한 재료로 탄생하는 미슐랭급 변신.",
+          "hook": "평범한 삼김의 반전! 이거 진짜 레스토랑?",
+          "category": "cvs-combo",
+          "dish_name": "불닭 치즈 리조또",
+          "recipe_id": "006bf070-47eb-415d-9648-3c3b96eb258c"
+        },
+        {
+          "id": "night-snack-39",
+          "title": "참깨라면X짜파게티 '마법의 야식' 꿀조합",
+          "channel": "잇햅",
+          "youtube_url": "https://www.youtube.com/watch?v=1B7fznAgm2g",
+          "estimated_duration": "1분",
+          "tags": {
+            "mood": [
+              "이불 속",
+              "혼술 한 잔"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "쇼츠",
+            "pairing": [
+              "맥주"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "퓨전"
+            ],
+            "ingredient_focus": [
+              "면"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "각기 다른 면이 섞여 더욱 깊어진 중독성.",
+          "hook": "어떻게 이런 풍미가? 라면 두 개로 역대급!",
+          "category": "cvs-combo",
+          "dish_name": "참짜라면",
+          "recipe_id": "22af51e0-2d25-4c0c-b36d-f1d5e488e3e2"
+        },
+        {
+          "id": "night-snack-40",
+          "title": "에어프라이어 '백종원 양념치킨' 옛날통닭",
+          "channel": "푼스",
+          "youtube_url": "https://www.youtube.com/watch?v=wjsAegsB4hg",
+          "estimated_duration": "30분",
+          "tags": {
+            "mood": [
+              "주말 밤",
+              "혼술 한 잔"
+            ],
+            "difficulty": "중급",
+            "time": "30분",
+            "format": "롱폼",
+            "pairing": [
+              "맥주"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "한식"
+            ],
+            "ingredient_focus": [
+              "고기"
+            ],
+            "budget": "보통"
+          },
+          "why_recommended": "바삭한 옛날 맛에 죄책감도 녹아내려.",
+          "hook": "에어프라이어로 갓 튀긴 치킨이라니?",
+          "category": "guilty",
+          "dish_name": "에어프라이어 양념통닭",
+          "recipe_id": "a1cf7554-ae26-4638-be32-32a508b624fd",
+          "failed": true
+        },
+        {
+          "id": "night-snack-41",
+          "title": "백종원 닭강정 '장사천재 백사장' 레시피",
+          "channel": "스푼비 SpoonB",
+          "youtube_url": "https://www.youtube.com/watch?v=YxamhygmEKY",
+          "estimated_duration": "15분",
+          "tags": {
+            "mood": [
+              "주말 밤",
+              "혼술 한 잔"
+            ],
+            "difficulty": "중급",
+            "time": "30분",
+            "format": "롱폼",
+            "pairing": [
+              "맥주"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "한식"
+            ],
+            "ingredient_focus": [
+              "고기"
+            ],
+            "budget": "보통"
+          },
+          "why_recommended": "이 맛은 배달보다 더 완벽할 거야.",
+          "hook": "유명 셰프 레시피로 만드는 달콤 바삭 한 입!",
+          "category": "guilty",
+          "dish_name": "백종원 닭강정",
+          "recipe_id": "4291416f-e8ec-402d-8948-42a98caa7060"
+        },
+        {
+          "id": "night-snack-42",
+          "title": "유쿡의 홈메이드 '뿌링클 치킨' 배달비 절약",
+          "channel": "유쿡",
+          "youtube_url": "https://www.youtube.com/watch?v=kIzGCxIRR-Q",
+          "estimated_duration": "20분",
+          "tags": {
+            "mood": [
+              "주말 밤",
+              "혼술 한 잔"
+            ],
+            "difficulty": "중급",
+            "time": "30분",
+            "format": "롱폼",
+            "pairing": [
+              "맥주"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "퓨전"
+            ],
+            "ingredient_focus": [
+              "고기"
+            ],
+            "budget": "보통"
+          },
+          "why_recommended": "비싼 배달비 없이 나만의 치킨 파티.",
+          "hook": "오늘은 집에서 뿌링클 가루 맘껏 뿌려보자!",
+          "category": "guilty",
+          "dish_name": "홈메이드 뿌링클",
+          "recipe_id": "513787e3-46b7-4956-98ee-870baecf0999",
+          "failed": true
+        },
+        {
+          "id": "night-snack-43",
+          "title": "에어프라이어 15분 '또띠아 피자' 야식",
+          "channel": "인콕",
+          "youtube_url": "https://www.youtube.com/watch?v=G1icdJN9TNI",
+          "estimated_duration": "15분",
+          "tags": {
+            "mood": [
+              "이불 속",
+              "혼자 보는 영화"
+            ],
+            "difficulty": "초보",
+            "time": "30분",
+            "format": "롱폼",
+            "pairing": [
+              "맥주"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "양식"
+            ],
+            "ingredient_focus": [
+              "치즈"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "복잡한 주말 야식, 이 한 판으로 끝!",
+          "hook": "단 15분! 이 정도면 충분히 행복하지 않을까?",
+          "category": "guilty",
+          "dish_name": "15분 또띠아 피자",
+          "recipe_id": "5a0515dd-7d03-414e-842c-c61ac3f51493"
+        },
+        {
+          "id": "night-snack-44",
+          "title": "염정아의 '피자토스트' 새벽 길티 야식",
+          "channel": "오오밥상",
+          "youtube_url": "https://www.youtube.com/watch?v=e3xcF4QQ9M0",
+          "estimated_duration": "5분",
+          "tags": {
+            "mood": [
+              "새벽 한 시",
+              "이불 속"
+            ],
+            "difficulty": "초보",
+            "time": "10분",
+            "format": "숏폼",
+            "pairing": [
+              "맥주"
+            ],
+            "occasion": [
+              "야식"
+            ],
+            "style": [
+              "양식"
+            ],
+            "ingredient_focus": [
+              "치즈"
+            ],
+            "budget": "가성비"
+          },
+          "why_recommended": "토스트에 피자를 얹는 건 최고의 선택이야.",
+          "hook": "잠 못 드는 새벽, 피자토스트로 위로받자!",
+          "category": "guilty",
+          "dish_name": "염정아 피자토스트",
+          "recipe_id": "58f5a183-f61b-4995-baa1-e376300fc3b7"
+        }
+      ],
+      "categories": [
+        {
+          "id": "quick-3",
+          "name": "3재료 5분",
+          "emoji": "🍳",
+          "concept": "재료 3개, 시간 5분. 자취생도 새벽에 부담 없이 만드는 초간단 야식."
+        },
+        {
+          "id": "guilt-free",
+          "name": "죄책감 0%",
+          "emoji": "🥗",
+          "concept": "다이어트 중에도 마음 편하게. 두부·곤약·오트밀·단호박으로 만드는 가벼운 야식."
+        },
+        {
+          "id": "ramen-mod",
+          "name": "라면 변신",
+          "emoji": "🍜",
+          "concept": "봉지 라면 하나로 새로운 한 그릇. 5분 만에 끝나는 라면 모디파이."
+        },
+        {
+          "id": "cvs-combo",
+          "name": "편의점 꿀조합",
+          "emoji": "🏪",
+          "concept": "편의점 갔다가 즉흥적으로 만드는 꿀조합. 가성비·간편함·중독성."
+        },
+        {
+          "id": "guilty",
+          "name": "길티 치킨피자",
+          "emoji": "🍗",
+          "concept": "내일은 운동! 오늘 밤은 진하게 가는 치킨·피자·튀김. 죄책감은 내일."
         }
       ]
     },
@@ -2023,923 +2896,6 @@
           "hook": "봄동의 진가는 양념 직전에 결정된다",
           "recipe_id": "648fdadf-7398-4826-a5cb-c818c02cba32",
           "failed": true
-        }
-      ]
-    },
-    {
-      "id": "night-snack",
-      "title": "밤에 땡기는",
-      "subtitle": "오늘 밤, 천사도 악마도 만족시키는 야식",
-      "color": "#6A4C93",
-      "mode": "dark",
-      "curator_quote": "오늘 밤, 천사도 악마도 만족시키는 야식",
-      "dishes": [
-        {
-          "id": "night-snack-17",
-          "title": "3분 완성 '계란마요 토스트'",
-          "channel": "자취요리신",
-          "youtube_url": "https://www.youtube.com/watch?v=0kFqX_L9G7I",
-          "estimated_duration": "1분",
-          "tags": {
-            "mood": [
-              "이불 속",
-              "새벽 한 시"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "쇼츠",
-            "pairing": [
-              "논알콜"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "디저트"
-            ],
-            "ingredient_focus": [
-              "달걀"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "따뜻한 한 조각이 마음을 채워.",
-          "hook": "배고프다고? 3분이면 충분해!",
-          "category": "quick-3",
-          "dish_name": "마요계란토스트",
-          "recipe_id": "d487cea4-60c9-4b24-bff7-2ac7213e18d5",
-          "failed": true
-        },
-        {
-          "id": "night-snack-21",
-          "title": "5분 완성 '간장버터우동' 자취 야식",
-          "channel": "간단한 맛남",
-          "youtube_url": "https://www.youtube.com/watch?v=KkSiTh7wx5M",
-          "estimated_duration": "5분",
-          "tags": {
-            "mood": [
-              "새벽 한 시",
-              "이불 속"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "쇼츠",
-            "pairing": [
-              "없음"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "일식"
-            ],
-            "ingredient_focus": [
-              "면"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "짭조름한 풍미가 입안 가득 춤춘다.",
-          "hook": "5분 만에 면 요리를 해내다니!",
-          "category": "quick-3",
-          "dish_name": "우동버터간장",
-          "recipe_id": "15a94765-0569-442f-9a4d-d8c6448f3b2b",
-          "failed": true
-        },
-        {
-          "id": "night-snack-22",
-          "title": "백종원의 '콘치즈' 인생 안주 레시피",
-          "channel": "백종원 PAIK JONG WON",
-          "youtube_url": "https://www.youtube.com/watch?v=zS_o6psOt9g",
-          "estimated_duration": "8분",
-          "tags": {
-            "mood": [
-              "혼술 한 잔",
-              "주말 밤"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "롱폼",
-            "pairing": [
-              "맥주"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "퓨전"
-            ],
-            "ingredient_focus": [
-              "치즈"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "한 입에 톡 터지는 달콤 짭짤함.",
-          "hook": "치즈 폭포 속 옥수수! 이거지!",
-          "category": "quick-3",
-          "dish_name": "치즈듬뿍콘",
-          "recipe_id": "9d342932-277a-4a6c-b43b-3cab77f87395",
-          "failed": true
-        },
-        {
-          "id": "night-snack-23",
-          "title": "일주일 세 번 먹는 '버터 누룽지 치즈밥'",
-          "channel": "꾸니로그",
-          "youtube_url": "https://www.youtube.com/watch?v=5vRSQcUfAM8",
-          "estimated_duration": "5분",
-          "tags": {
-            "mood": [
-              "새벽 한 시",
-              "이불 속"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "쇼츠",
-            "pairing": [
-              "없음"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "한식"
-            ],
-            "ingredient_focus": [
-              "밥"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "딱 5분, 구수한 치즈 향에 위로받아.",
-          "hook": "식사? 야식? 바삭한 누룽지 치즈밥!",
-          "category": "quick-3",
-          "dish_name": "버터치즈누룽지",
-          "recipe_id": "27774a31-8207-41c3-bd5a-1bbf4612913e",
-          "failed": true
-        },
-        {
-          "id": "night-snack-24",
-          "title": "감칠맛 폭발 '새우젓 계란찜' 5분 야식",
-          "channel": "나의 작은 부엌",
-          "youtube_url": "https://www.youtube.com/watch?v=27MfMpvfAPw",
-          "estimated_duration": "3분",
-          "tags": {
-            "mood": [
-              "새벽 한 시",
-              "이불 속"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "쇼츠",
-            "pairing": [
-              "없음"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "한식"
-            ],
-            "ingredient_focus": [
-              "달걀"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "부드러운 한 입, 지친 나를 토닥여줘.",
-          "hook": "이 촉촉함, 무려 5분만에 완성?",
-          "category": "quick-3",
-          "dish_name": "새우젓계란찜",
-          "recipe_id": "31744922-2cea-49bd-a1f4-f4290533c583",
-          "failed": true
-        },
-        {
-          "id": "night-snack-25",
-          "title": "다이어트 중 떡볶이 땡길 때 '두부 떡볶이'",
-          "channel": "김미푸드",
-          "youtube_url": "https://www.youtube.com/watch?v=Vk73tNxwV6U",
-          "estimated_duration": "2분",
-          "tags": {
-            "mood": [
-              "새벽 한 시",
-              "이불 속"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "쇼츠",
-            "pairing": [
-              "없음"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "한식"
-            ],
-            "ingredient_focus": [
-              "떡"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "말랑한 두부로 맵달하게 즐기는 건강 간식",
-          "hook": "떡볶이 유혹, 더 이상 참지 마!",
-          "category": "guilt-free",
-          "dish_name": "두부 떡볶이",
-          "recipe_id": "b5a03ccf-bd08-4145-bb56-794183f6d01b",
-          "failed": true
-        },
-        {
-          "id": "night-snack-26",
-          "title": "감칠맛 폭발 '곤약면 비빔국수' 다이어트 야식",
-          "channel": "또먹",
-          "youtube_url": "https://www.youtube.com/watch?v=Hi-ikD3bLKU",
-          "estimated_duration": "3분",
-          "tags": {
-            "mood": [
-              "새벽 한 시",
-              "이불 속"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "숏폼",
-            "pairing": [
-              "없음"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "한식"
-            ],
-            "ingredient_focus": [
-              "면"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "탱글한 면발에 폭발하는 산뜻한 만족감",
-          "hook": "매콤새콤! 이 감칠맛은 못 참지",
-          "category": "guilt-free",
-          "dish_name": "곤약 비빔국수",
-          "recipe_id": "ecea9392-a33a-4aaa-a81b-3b0856eae1eb",
-          "failed": true
-        },
-        {
-          "id": "night-snack-27",
-          "title": "김신영 야식 '38kg 감량' 또띠아 케사디아",
-          "channel": "초이쿡",
-          "youtube_url": "https://www.youtube.com/watch?v=CZlwG_dVGJ4",
-          "estimated_duration": "2분",
-          "tags": {
-            "mood": [
-              "새벽 한 시",
-              "이불 속"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "쇼츠",
-            "pairing": [
-              "없음"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "퓨전"
-            ],
-            "ingredient_focus": [
-              "치즈"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "바삭 촉촉한데 건강까지 챙긴 치즈 간식",
-          "hook": "38kg 감량, 그 비법 간식이 여기?",
-          "category": "guilt-free",
-          "dish_name": "또띠아 케사디아",
-          "recipe_id": "071cab39-9943-461a-a2fa-abe58e75413e",
-          "failed": true
-        },
-        {
-          "id": "night-snack-28",
-          "title": "1분다이어터 '오트밀 한 그릇' 야식",
-          "channel": "1분다이어터 1mindiet",
-          "youtube_url": "https://www.youtube.com/watch?v=rzCYWhimwNs",
-          "estimated_duration": "1분",
-          "tags": {
-            "mood": [
-              "새벽 한 시",
-              "이불 속"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "쇼츠",
-            "pairing": [
-              "없음"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "한식"
-            ],
-            "ingredient_focus": [
-              "밥"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "빠르게 뚝딱 만들어 속 편하게 채우는 꿀조합",
-          "hook": "단 5분이면 나만의 건강 야식 완성!",
-          "category": "guilt-free",
-          "dish_name": "든든 오트밀",
-          "recipe_id": "9f448712-e26a-427b-ba52-3cae0691c884",
-          "failed": true
-        },
-        {
-          "id": "night-snack-29",
-          "title": "치즈 품은 '단호박 구이' 죄책감 ZERO 야식",
-          "channel": "워킹맘의 집밥",
-          "youtube_url": "https://www.youtube.com/watch?v=LtK32RnfgDA",
-          "estimated_duration": "10분",
-          "tags": {
-            "mood": [
-              "새벽 한 시",
-              "이불 속"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "쇼츠",
-            "pairing": [
-              "없음"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "퓨전"
-            ],
-            "ingredient_focus": [
-              "채소"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "달콤짭짤한 맛으로 하루의 피로를 녹이는 위로",
-          "hook": "달콤 촉촉한 단호박에 고소한 치즈가 쏙!",
-          "category": "guilt-free",
-          "dish_name": "치즈 단호박구이",
-          "recipe_id": "56710a02-b187-4c21-99bd-85c9aa9aeb25",
-          "failed": true
-        },
-        {
-          "id": "night-snack-30",
-          "title": "건두부 올린 '마라 짜파게티' 끝판왕",
-          "channel": "모루",
-          "youtube_url": "https://www.youtube.com/watch?v=4nZSgfgACWM",
-          "estimated_duration": "2분",
-          "tags": {
-            "mood": [
-              "새벽 한 시",
-              "이불 속"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "쇼츠",
-            "pairing": [
-              "맥주"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "퓨전"
-            ],
-            "ingredient_focus": [
-              "면"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "평범함에 더해지는 이국적인 매력.",
-          "hook": "이국적 향신료가 부르는 짜파게티의 변주",
-          "category": "ramen-mod",
-          "dish_name": "마라 짜파게티",
-          "recipe_id": "70e029ad-fc9d-48eb-b947-30062bd7cf41",
-          "failed": true
-        },
-        {
-          "id": "night-snack-31",
-          "title": "백종원의 '부대찌개맛 뿌햄라면' 꿀팁",
-          "channel": "백종원 PAIK JONG WON",
-          "youtube_url": "https://www.youtube.com/watch?v=qWI4b7BL2eA",
-          "estimated_duration": "3분",
-          "tags": {
-            "mood": [
-              "새벽 한 시",
-              "퇴근길"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "숏폼",
-            "pairing": [
-              "맥주"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "한식"
-            ],
-            "ingredient_focus": [
-              "면"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "끓이면 바로 든든한 한 끼.",
-          "hook": "이거야말로 라면의 진화!",
-          "category": "ramen-mod",
-          "dish_name": "부대찌개맛 라면",
-          "recipe_id": "6542412b-8b36-4834-96a0-ee8885fdb4d6",
-          "failed": true
-        },
-        {
-          "id": "night-snack-32",
-          "title": "치즈 폭탄 '까르보 불닭' 분식집 맛",
-          "channel": "FFAST FOOD",
-          "youtube_url": "https://www.youtube.com/watch?v=NXNIDr_glr8",
-          "estimated_duration": "5분",
-          "tags": {
-            "mood": [
-              "이불 속",
-              "혼술 한 잔"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "쇼츠",
-            "pairing": [
-              "맥주"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "퓨전"
-            ],
-            "ingredient_focus": [
-              "치즈"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "매운맛을 고소함으로 감싸다.",
-          "hook": "크림 소스처럼 꾸덕한 한 입?",
-          "category": "ramen-mod",
-          "dish_name": "까르보 불닭",
-          "recipe_id": "3076a022-d27e-4b50-a9b2-b68a35119fe0",
-          "failed": true
-        },
-        {
-          "id": "night-snack-33",
-          "title": "진짜 분식집 '떡라면' 끓이는 법",
-          "channel": "한끼대첩:간단한 요리 레시피",
-          "youtube_url": "https://www.youtube.com/watch?v=T289nNqfxt4",
-          "estimated_duration": "5분",
-          "tags": {
-            "mood": [
-              "새벽 한 시",
-              "이불 속"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "롱폼",
-            "pairing": [
-              "없음"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "한식"
-            ],
-            "ingredient_focus": [
-              "떡"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "추억의 맛이 그리울 때 딱.",
-          "hook": "집에서 이 맛을 재현한다고?",
-          "category": "ramen-mod",
-          "dish_name": "분식집 떡라면",
-          "recipe_id": "28d905b5-7fbd-4d32-828f-ac8ba94f8b4a",
-          "failed": true
-        },
-        {
-          "id": "night-snack-34",
-          "title": "성시경의 '극강 치즈 라면' 꾸덕 야식",
-          "channel": "모트리",
-          "youtube_url": "https://www.youtube.com/watch?v=nS6bs5hDB50",
-          "estimated_duration": "5분",
-          "tags": {
-            "mood": [
-              "혼술 한 잔",
-              "주말 밤"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "롱폼",
-            "pairing": [
-              "맥주"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "퓨전"
-            ],
-            "ingredient_focus": [
-              "치즈"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "입안 가득 채우는 깊은 고소함.",
-          "hook": "치즈 여섯 장은 넣어야 이 정도!",
-          "category": "ramen-mod",
-          "dish_name": "꾸덕 치즈 라면",
-          "recipe_id": "c066c80f-6d09-4a13-a46e-f7a12a04250f",
-          "failed": true
-        },
-        {
-          "id": "night-snack-35",
-          "title": "편의점 끝판왕 '마크정식' 6470원 야식",
-          "channel": "헬로푸드",
-          "youtube_url": "https://www.youtube.com/watch?v=S7P7m_zcf3s",
-          "estimated_duration": "3분",
-          "tags": {
-            "mood": [
-              "새벽 한 시",
-              "이불 속"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "숏폼",
-            "pairing": [
-              "맥주"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "퓨전"
-            ],
-            "ingredient_focus": [
-              "떡"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "모두가 인정하는 특별한 식사, 오늘 어때?",
-          "hook": "이게 바로 편의점 만찬의 정석!",
-          "category": "cvs-combo",
-          "dish_name": "마크정식",
-          "recipe_id": "a1edace1-0e76-4820-a258-033241179870",
-          "failed": true
-        },
-        {
-          "id": "night-snack-36",
-          "title": "겨울 필수 '오모리 김치찌개 컵라면' 꿀조합",
-          "channel": "20대 뭐 하지?",
-          "youtube_url": "https://www.youtube.com/watch?v=S7qaHSyz-kY",
-          "estimated_duration": "1분",
-          "tags": {
-            "mood": [
-              "새벽 한 시",
-              "혼술 한 잔"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "쇼츠",
-            "pairing": [
-              "소주"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "한식"
-            ],
-            "ingredient_focus": [
-              "면"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "그릇 가득 추위 녹이는 든든한 포만감.",
-          "hook": "싸늘한 날, 뜨끈한 위로가 필요하다면?",
-          "category": "cvs-combo",
-          "dish_name": "오모리 라면죽",
-          "recipe_id": "88ecc440-94f2-4bab-9aba-6c2a05d93751",
-          "failed": true
-        },
-        {
-          "id": "night-snack-37",
-          "title": "편의점 환상조합 '사리곰탕 만둣국' 1분 컷",
-          "channel": "라면아저씨 Ramyun Ahjussi",
-          "youtube_url": "https://www.youtube.com/watch?v=Tt9cA1Cj9hw",
-          "estimated_duration": "1분",
-          "tags": {
-            "mood": [
-              "새벽 한 시",
-              "이불 속"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "쇼츠",
-            "pairing": [
-              "없음"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "한식"
-            ],
-            "ingredient_focus": [
-              "면"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "놀랍도록 빠르게 완성되는 고급진 별미.",
-          "hook": "1분 만에 뚝딱! 이런 환상의 궁합 봤어?",
-          "category": "cvs-combo",
-          "dish_name": "사리곰탕 만둣국",
-          "recipe_id": "ff7b3062-1eec-4d5e-8f88-0cdc85d9bbd8",
-          "failed": true
-        },
-        {
-          "id": "night-snack-38",
-          "title": "삼각김밥으로 '불닭 치즈 리조또' 변신",
-          "channel": "직딩쿠킹",
-          "youtube_url": "https://www.youtube.com/watch?v=bIFPlKelCtI",
-          "estimated_duration": "5분",
-          "tags": {
-            "mood": [
-              "이불 속",
-              "혼술 한 잔"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "쇼츠",
-            "pairing": [
-              "맥주"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "퓨전"
-            ],
-            "ingredient_focus": [
-              "치즈"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "흔한 재료로 탄생하는 미슐랭급 변신.",
-          "hook": "평범한 삼김의 반전! 이거 진짜 레스토랑?",
-          "category": "cvs-combo",
-          "dish_name": "불닭 치즈 리조또",
-          "recipe_id": "006bf070-47eb-415d-9648-3c3b96eb258c",
-          "failed": true
-        },
-        {
-          "id": "night-snack-39",
-          "title": "참깨라면X짜파게티 '마법의 야식' 꿀조합",
-          "channel": "잇햅",
-          "youtube_url": "https://www.youtube.com/watch?v=1B7fznAgm2g",
-          "estimated_duration": "1분",
-          "tags": {
-            "mood": [
-              "이불 속",
-              "혼술 한 잔"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "쇼츠",
-            "pairing": [
-              "맥주"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "퓨전"
-            ],
-            "ingredient_focus": [
-              "면"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "각기 다른 면이 섞여 더욱 깊어진 중독성.",
-          "hook": "어떻게 이런 풍미가? 라면 두 개로 역대급!",
-          "category": "cvs-combo",
-          "dish_name": "참짜라면",
-          "recipe_id": "22af51e0-2d25-4c0c-b36d-f1d5e488e3e2",
-          "failed": true
-        },
-        {
-          "id": "night-snack-40",
-          "title": "에어프라이어 '백종원 양념치킨' 옛날통닭",
-          "channel": "푼스",
-          "youtube_url": "https://www.youtube.com/watch?v=wjsAegsB4hg",
-          "estimated_duration": "30분",
-          "tags": {
-            "mood": [
-              "주말 밤",
-              "혼술 한 잔"
-            ],
-            "difficulty": "중급",
-            "time": "30분",
-            "format": "롱폼",
-            "pairing": [
-              "맥주"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "한식"
-            ],
-            "ingredient_focus": [
-              "고기"
-            ],
-            "budget": "보통"
-          },
-          "why_recommended": "바삭한 옛날 맛에 죄책감도 녹아내려.",
-          "hook": "에어프라이어로 갓 튀긴 치킨이라니?",
-          "category": "guilty",
-          "dish_name": "에어프라이어 양념통닭",
-          "recipe_id": "a1cf7554-ae26-4638-be32-32a508b624fd",
-          "failed": true
-        },
-        {
-          "id": "night-snack-41",
-          "title": "백종원 닭강정 '장사천재 백사장' 레시피",
-          "channel": "스푼비 SpoonB",
-          "youtube_url": "https://www.youtube.com/watch?v=YxamhygmEKY",
-          "estimated_duration": "15분",
-          "tags": {
-            "mood": [
-              "주말 밤",
-              "혼술 한 잔"
-            ],
-            "difficulty": "중급",
-            "time": "30분",
-            "format": "롱폼",
-            "pairing": [
-              "맥주"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "한식"
-            ],
-            "ingredient_focus": [
-              "고기"
-            ],
-            "budget": "보통"
-          },
-          "why_recommended": "이 맛은 배달보다 더 완벽할 거야.",
-          "hook": "유명 셰프 레시피로 만드는 달콤 바삭 한 입!",
-          "category": "guilty",
-          "dish_name": "백종원 닭강정",
-          "recipe_id": "4291416f-e8ec-402d-8948-42a98caa7060",
-          "failed": true
-        },
-        {
-          "id": "night-snack-42",
-          "title": "유쿡의 홈메이드 '뿌링클 치킨' 배달비 절약",
-          "channel": "유쿡",
-          "youtube_url": "https://www.youtube.com/watch?v=kIzGCxIRR-Q",
-          "estimated_duration": "20분",
-          "tags": {
-            "mood": [
-              "주말 밤",
-              "혼술 한 잔"
-            ],
-            "difficulty": "중급",
-            "time": "30분",
-            "format": "롱폼",
-            "pairing": [
-              "맥주"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "퓨전"
-            ],
-            "ingredient_focus": [
-              "고기"
-            ],
-            "budget": "보통"
-          },
-          "why_recommended": "비싼 배달비 없이 나만의 치킨 파티.",
-          "hook": "오늘은 집에서 뿌링클 가루 맘껏 뿌려보자!",
-          "category": "guilty",
-          "dish_name": "홈메이드 뿌링클",
-          "recipe_id": "513787e3-46b7-4956-98ee-870baecf0999",
-          "failed": true
-        },
-        {
-          "id": "night-snack-43",
-          "title": "에어프라이어 15분 '또띠아 피자' 야식",
-          "channel": "인콕",
-          "youtube_url": "https://www.youtube.com/watch?v=G1icdJN9TNI",
-          "estimated_duration": "15분",
-          "tags": {
-            "mood": [
-              "이불 속",
-              "혼자 보는 영화"
-            ],
-            "difficulty": "초보",
-            "time": "30분",
-            "format": "롱폼",
-            "pairing": [
-              "맥주"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "양식"
-            ],
-            "ingredient_focus": [
-              "치즈"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "복잡한 주말 야식, 이 한 판으로 끝!",
-          "hook": "단 15분! 이 정도면 충분히 행복하지 않을까?",
-          "category": "guilty",
-          "dish_name": "15분 또띠아 피자",
-          "recipe_id": "5a0515dd-7d03-414e-842c-c61ac3f51493",
-          "failed": true
-        },
-        {
-          "id": "night-snack-44",
-          "title": "염정아의 '피자토스트' 새벽 길티 야식",
-          "channel": "오오밥상",
-          "youtube_url": "https://www.youtube.com/watch?v=e3xcF4QQ9M0",
-          "estimated_duration": "5분",
-          "tags": {
-            "mood": [
-              "새벽 한 시",
-              "이불 속"
-            ],
-            "difficulty": "초보",
-            "time": "10분",
-            "format": "숏폼",
-            "pairing": [
-              "맥주"
-            ],
-            "occasion": [
-              "야식"
-            ],
-            "style": [
-              "양식"
-            ],
-            "ingredient_focus": [
-              "치즈"
-            ],
-            "budget": "가성비"
-          },
-          "why_recommended": "토스트에 피자를 얹는 건 최고의 선택이야.",
-          "hook": "잠 못 드는 새벽, 피자토스트로 위로받자!",
-          "category": "guilty",
-          "dish_name": "염정아 피자토스트",
-          "recipe_id": "58f5a183-f61b-4995-baa1-e376300fc3b7",
-          "failed": true
-        }
-      ],
-      "categories": [
-        {
-          "id": "quick-3",
-          "name": "3재료 5분",
-          "emoji": "🍳",
-          "concept": "재료 3개, 시간 5분. 자취생도 새벽에 부담 없이 만드는 초간단 야식."
-        },
-        {
-          "id": "guilt-free",
-          "name": "죄책감 0%",
-          "emoji": "🥗",
-          "concept": "다이어트 중에도 마음 편하게. 두부·곤약·오트밀·단호박으로 만드는 가벼운 야식."
-        },
-        {
-          "id": "ramen-mod",
-          "name": "라면 변신",
-          "emoji": "🍜",
-          "concept": "봉지 라면 하나로 새로운 한 그릇. 5분 만에 끝나는 라면 모디파이."
-        },
-        {
-          "id": "cvs-combo",
-          "name": "편의점 꿀조합",
-          "emoji": "🏪",
-          "concept": "편의점 갔다가 즉흥적으로 만드는 꿀조합. 가성비·간편함·중독성."
-        },
-        {
-          "id": "guilty",
-          "name": "길티 치킨피자",
-          "emoji": "🍗",
-          "concept": "내일은 운동! 오늘 밤은 진하게 가는 치킨·피자·튀김. 죄책감은 내일."
         }
       ]
     },

--- a/src/entities/affiliate/api/affiliate-api.ts
+++ b/src/entities/affiliate/api/affiliate-api.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { client } from '@/src/shared/api';
+import { client, parseOrNull } from '@/src/shared/api';
 
 // ─── Raw schemas ─────────────────────────────────────────────────
 const RawCoupangProductSchema = z
@@ -13,8 +13,7 @@ const RawCoupangProductSchema = z
     productName: z.string(),
     productPrice: z.number(),
     productUrl: z.string(),
-  })
-  .passthrough();
+  });
 
 const RawCoupangSearchResponseSchema = z
   .object({
@@ -23,13 +22,12 @@ const RawCoupangSearchResponseSchema = z
         coupangProducts: z.array(RawCoupangProductSchema).default([]),
       })
       .nullish(),
-  })
-  .passthrough();
+  });
 
 type RawCoupangProduct = z.infer<typeof RawCoupangProductSchema>;
 
 // ─── Client type ─────────────────────────────────────────────────
-export interface IngredientProduct {
+export type IngredientProduct = {
   id: string;
   name: string; // 재료명
   description: string; // 상품명
@@ -62,12 +60,9 @@ export async function searchCoupangCheapest(ingredientName: string): Promise<Ing
     const res = await client.get('/affiliate/search/coupang', {
       params: { keyword: ingredientName },
     });
-    const parsed = RawCoupangSearchResponseSchema.safeParse(res.data);
-    if (!parsed.success) {
-      console.warn('[CoupangAPI] schema error:', parsed.error.issues);
-      return null;
-    }
-    const products = parsed.data.coupangProducts?.coupangProducts ?? [];
+    const parsed = parseOrNull(RawCoupangSearchResponseSchema, res.data, 'CoupangAPI');
+    if (!parsed) return null;
+    const products = parsed.coupangProducts?.coupangProducts ?? [];
     if (products.length === 0) return null;
 
     const cheapest = products.reduce((prev, curr) =>

--- a/src/entities/balance/api/balance-api.ts
+++ b/src/entities/balance/api/balance-api.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { isAxiosError } from 'axios';
-import { client } from '@/src/shared/api';
+import { client, parseOrNull } from '@/src/shared/api';
 
 // ─── Constants ───────────────────────────────────────────────────
 export const SHARE_LIMIT = 5;
@@ -10,22 +10,19 @@ export const CREDIT_PER_SHARE = 5;
 const RawBalanceSchema = z
   .object({
     balance: z.number().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawShareResponseSchema = z
   .object({
     share_count: z.number().nullish(),
-    shareCount: z.number().nullish(),
-  })
-  .passthrough();
+  });
 
 // ─── Client types ────────────────────────────────────────────────
-export interface Balance {
+export type Balance = {
   balance: number;
 }
 
-export interface RechargeResponse {
+export type RechargeResponse = {
   amount: number;
   remainingCount: number;
 }
@@ -48,12 +45,9 @@ const ERROR_CODES = {
 export async function fetchBalance(): Promise<Balance> {
   try {
     const res = await client.get('/credit/balance');
-    const parsed = RawBalanceSchema.safeParse(res.data);
-    if (!parsed.success) {
-      console.warn('[BalanceAPI] schema error:', parsed.error.issues);
-      return { balance: 0 };
-    }
-    return { balance: parsed.data.balance ?? 0 };
+    const parsed = parseOrNull(RawBalanceSchema, res.data, 'BalanceAPI');
+    if (!parsed) return { balance: 0 };
+    return { balance: parsed.balance ?? 0 };
   } catch (err: any) {
     console.warn('[BalanceAPI] fetchBalance error:', err?.response?.status, err?.message);
     return { balance: 0 };
@@ -63,12 +57,9 @@ export async function fetchBalance(): Promise<Balance> {
 export async function completeRecharge(): Promise<RechargeResponse> {
   try {
     const res = await client.post('/users/share');
-    const parsed = RawShareResponseSchema.safeParse(res.data);
-    if (!parsed.success) {
-      console.warn('[BalanceAPI] share schema error:', parsed.error.issues);
-      throw new Error('충전 응답 형식이 올바르지 않아요.');
-    }
-    const shareCount = parsed.data.share_count ?? parsed.data.shareCount ?? 0;
+    const parsed = parseOrNull(RawShareResponseSchema, res.data, 'BalanceAPI/share');
+    if (!parsed) throw new Error('충전 응답 형식이 올바르지 않아요.');
+    const shareCount = parsed.share_count ?? 0;
     return {
       amount: CREDIT_PER_SHARE,
       remainingCount: Math.max(SHARE_LIMIT - shareCount, 0),

--- a/src/entities/recipe-overview/api/recipe-overview-api.ts
+++ b/src/entities/recipe-overview/api/recipe-overview-api.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { client } from '@/src/shared/api';
+import { client, parseOrNull } from '@/src/shared/api';
 
 /**
  * 단일 레시피의 가벼운 메타데이터.
@@ -13,7 +13,7 @@ import { client } from '@/src/shared/api';
 
 const RawRecipeTagSchema = z.object({
   name: z.string(),
-}).passthrough();
+});
 
 const RawRecipeOverviewSchema = z
   .object({
@@ -31,12 +31,11 @@ const RawRecipeOverviewSchema = z
     videoThumbnailUrl: z.string(),
     videoSeconds: z.number().int(),
     creditCost: z.number().nullish(),
-  })
-  .passthrough();
+  });
 
 type RawRecipeOverview = z.infer<typeof RawRecipeOverviewSchema>;
 
-export interface RecipeOverview {
+export type RecipeOverview = {
   recipeId: string;
   recipeTitle: string;
   description: string;
@@ -77,12 +76,9 @@ export async function fetchRecipeOverview(
 ): Promise<RecipeOverview | null> {
   try {
     const res = await client.get(`/recipes/overview/${recipeId}`);
-    const parsed = RawRecipeOverviewSchema.safeParse(res.data);
-    if (!parsed.success) {
-      console.warn('[RecipeOverviewAPI] schema error:', parsed.error.issues);
-      return null;
-    }
-    return toRecipeOverview(parsed.data);
+    const parsed = parseOrNull(RawRecipeOverviewSchema, res.data, 'RecipeOverviewAPI');
+    if (!parsed) return null;
+    return toRecipeOverview(parsed);
   } catch (err: any) {
     console.warn(
       '[RecipeOverviewAPI] fetch error:',

--- a/src/entities/recipe-report/api/recipe-report-api.ts
+++ b/src/entities/recipe-report/api/recipe-report-api.ts
@@ -10,7 +10,7 @@ export const RecipeReportReasonSchema = z.enum([
 
 export type RecipeReportReason = z.infer<typeof RecipeReportReasonSchema>;
 
-export interface RecipeReportRequest {
+export type RecipeReportRequest = {
   reason: RecipeReportReason;
   description: string | null;
 }

--- a/src/entities/recipe/api/recipe-api.ts
+++ b/src/entities/recipe/api/recipe-api.ts
@@ -10,23 +10,20 @@ const RawVideoInfoSchema = z
     video_id: z.string().nullish(),
     video_type: z.enum(['SHORTS', 'NORMAL']).nullish(),
     video_title: z.string().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawMetaSchema = z
   .object({
     description: z.string().nullish(),
     servings: z.number().nullish(),
     cooking_time: z.number().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawAmountSchema = z
   .object({
     value: z.number().nullish(),
     unit: z.string().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawIngredientSchema = z
   .object({
@@ -35,41 +32,32 @@ const RawIngredientSchema = z
     unit: z.string().nullish(),
     substitute: z.string().nullish(),
     selection_tip: z.string().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawStepDetailSchema = z
   .object({
     text: z.string().nullish(),
-    content: z.string().nullish(),
     start: z.number().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawSceneSchema = z
   .object({
     label: z.string().nullish(),
     start_time: z.number().nullish(),
     end_time: z.number().nullish(),
-    start: z.number().nullish(),
-    end: z.number().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawStepSchema = z
   .object({
     step_order: z.number().nullish(),
-    order: z.number().nullish(),
     subtitle: z.string().nullish(),
-    title: z.string().nullish(),
     details: z.array(RawStepDetailSchema).default([]),
     scenes: z.array(RawSceneSchema).nullish(),
     tip: z.any().nullish(),
     knowledge: z.any().nullish(),
     timer_seconds: z.number().nullish(),
     heat_level: z.string().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawRecipeResponseSchema = z
   .object({
@@ -77,8 +65,7 @@ const RawRecipeResponseSchema = z
     recipe_detail_meta: RawMetaSchema.optional(),
     recipe_ingredient: z.array(RawIngredientSchema).default([]),
     recipe_steps: z.array(RawStepSchema).default([]),
-  })
-  .passthrough();
+  });
 
 type RawIngredient = z.infer<typeof RawIngredientSchema>;
 type RawStep = z.infer<typeof RawStepSchema>;
@@ -118,17 +105,17 @@ function toScenesFromDetails(details: RawStepDetail[]) {
 function toScenesFromScenes(scenes: RawScene[]) {
   return scenes.map((sc) => ({
     label: sc.label ?? '',
-    start: formatSeconds(sc.start_time ?? sc.start ?? 0),
-    end: formatSeconds(sc.end_time ?? sc.end ?? 0),
+    start: formatSeconds(sc.start_time ?? 0),
+    end: formatSeconds(sc.end_time ?? 0),
   }));
 }
 
 function toStep(raw: RawStep) {
   return {
-    order: raw.step_order ?? raw.order ?? 0,
-    title: raw.subtitle ?? raw.title ?? '',
+    order: raw.step_order ?? 0,
+    title: raw.subtitle ?? '',
     description: (raw.details ?? []).map((d) => ({
-      content: d.text ?? d.content ?? '',
+      content: d.text ?? '',
       start: formatSeconds(d.start ?? 0),
     })),
     tip: raw.tip ?? null,

--- a/src/entities/recipe/api/recipe-create-api.ts
+++ b/src/entities/recipe/api/recipe-create-api.ts
@@ -14,30 +14,24 @@ export enum RecipeStatus {
 const RawCreateRecipeResponseSchema = z
   .object({
     recipe_id: z.string().nullish(),
-    recipeId: z.string().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawProgressResponseSchema = z
   .object({
     recipe_status: z.string().nullish(),
-    recipeStatus: z.string().nullish(),
-  })
-  .passthrough();
+  });
 
 // ─── APIs ────────────────────────────────────────────────────────
 
 export async function createRecipe(videoUrl: string): Promise<string> {
-  const res = await client.post('/recipes', { video_url: videoUrl, videoUrl });
+  const res = await client.post('/recipes', { video_url: videoUrl });
   const parsed = RawCreateRecipeResponseSchema.parse(res.data);
-  const recipeId = parsed.recipe_id ?? parsed.recipeId;
-  if (!recipeId) throw new Error('레시피 ID를 받지 못했어요');
-  return recipeId;
+  if (!parsed.recipe_id) throw new Error('레시피 ID를 받지 못했어요');
+  return parsed.recipe_id;
 }
 
 export async function fetchRecipeProgress(recipeId: string): Promise<RecipeStatus> {
   const res = await client.get(`/recipes/progress/${recipeId}`);
   const parsed = RawProgressResponseSchema.parse(res.data);
-  const status = (parsed.recipe_status ?? parsed.recipeStatus) as RecipeStatus | undefined;
-  return status ?? RecipeStatus.IN_PROGRESS;
+  return (parsed.recipe_status as RecipeStatus | undefined) ?? RecipeStatus.IN_PROGRESS;
 }

--- a/src/entities/recipe/api/recipe-detail-api.ts
+++ b/src/entities/recipe/api/recipe-detail-api.ts
@@ -10,54 +10,45 @@ const RawVideoInfoSchema = z
     video_seconds: z.number().nullish(),
     video_title: z.string().nullish(),
     channel_title: z.string().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawIngredientAmountSchema = z
   .object({
     value: z.number().nullish(),
     unit: z.string().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawIngredientSchema = z
   .object({
     name: z.string(),
     amount: z.union([z.number(), RawIngredientAmountSchema]).nullish(),
     unit: z.string().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawStepDetailSchema = z
   .object({
     text: z.string().nullish(),
-    content: z.string().nullish(),
     start: z.number().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawStepSchema = z
   .object({
     step_order: z.number().nullish(),
-    order: z.number().nullish(),
     subtitle: z.string().nullish(),
-    title: z.string().nullish(),
     start_time: z.number().nullish(),
     details: z.array(RawStepDetailSchema).default([]),
-  })
-  .passthrough();
+  });
 
 const RawRecipeDetailMetaSchema = z
   .object({
     description: z.string().nullish(),
     cooking_time: z.number().nullish(),
     servings: z.number().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawRecipeTagSchema = z.union([
   z.string(),
-  z.object({ name: z.string() }).passthrough(),
+  z.object({ name: z.string() }),
 ]);
 
 const RawRecipeDetailResponseSchema = z
@@ -68,8 +59,7 @@ const RawRecipeDetailResponseSchema = z
     recipe_steps: z.array(RawStepSchema).default([]),
     recipe_tags: z.array(RawRecipeTagSchema).default([]),
     view_status: z.any().nullish(),
-  })
-  .passthrough();
+  });
 
 type RawIngredient = z.infer<typeof RawIngredientSchema>;
 type RawStep = z.infer<typeof RawStepSchema>;
@@ -78,7 +68,7 @@ type RawVideoInfo = z.infer<typeof RawVideoInfoSchema>;
 
 // ─── Client types ────────────────────────────────────────────────
 
-export interface VideoInfo {
+export type VideoInfo = {
   videoId: string;
   videoThumbnailUrl: string;
   videoSeconds: number;
@@ -86,25 +76,25 @@ export interface VideoInfo {
   channelTitle: string;
 }
 
-export interface Ingredient {
+export type Ingredient = {
   name: string;
   amount: number | null;
   unit: string | null;
 }
 
-export interface StepDetail {
+export type StepDetail = {
   text: string;
   start: number;
 }
 
-export interface RecipeStep {
+export type RecipeStep = {
   stepOrder: number;
   subtitle: string;
   startTime: number;
   details: StepDetail[];
 }
 
-export interface RecipeDetail {
+export type RecipeDetail = {
   recipeId: string;
   videoInfo: VideoInfo;
   description: string;
@@ -144,15 +134,15 @@ function toIngredient(raw: RawIngredient): Ingredient {
 
 function toStepDetail(raw: RawStepDetail): StepDetail {
   return {
-    text: raw.text ?? raw.content ?? '',
+    text: raw.text ?? '',
     start: raw.start ?? 0,
   };
 }
 
 function toStep(raw: RawStep): RecipeStep {
   return {
-    stepOrder: raw.step_order ?? raw.order ?? 0,
-    subtitle: raw.subtitle ?? raw.title ?? '',
+    stepOrder: raw.step_order ?? 0,
+    subtitle: raw.subtitle ?? '',
     startTime: raw.start_time ?? 0,
     details: (raw.details ?? []).map(toStepDetail),
   };

--- a/src/entities/recipe/api/recommend-api.ts
+++ b/src/entities/recipe/api/recommend-api.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { client } from '@/src/shared/api';
+import { client, parseOrNull } from '@/src/shared/api';
 
 export enum RecommendType {
   CHEF = 'CHEF',
@@ -20,22 +20,20 @@ const RawRecommendRecipeSchema = z
     servings: z.number().nullish(),
     description: z.string().nullish(),
     credit_cost: z.number().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawRecommendResponseSchema = z
   .object({
     recommend_recipes: z.array(RawRecommendRecipeSchema).default([]),
     next_cursor: z.string().nullish(),
     has_next: z.boolean().nullish(),
-  })
-  .passthrough();
+  });
 
 type RawRecommendRecipe = z.infer<typeof RawRecommendRecipeSchema>;
 
 // ─── Client type ─────────────────────────────────────────────────
 
-export interface RecommendRecipe {
+export type RecommendRecipe = {
   recipeId: string;
   recipeTitle: string;
   videoThumbnailUrl: string;
@@ -47,7 +45,7 @@ export interface RecommendRecipe {
   creditCost: number;
 }
 
-export interface RecommendRecipesPage {
+export type RecommendRecipesPage = {
   data: RecommendRecipe[];
   nextCursor: string | null;
   hasNext: boolean;
@@ -79,16 +77,13 @@ export async function fetchRecommendRecipes(
       params: { query: 'ALL' },
     });
 
-    const parsed = RawRecommendResponseSchema.safeParse(res.data);
-    if (!parsed.success) {
-      console.warn(`[RecommendAPI] schema error for ${recommendType}:`, parsed.error.issues);
-      return { data: [], nextCursor: null, hasNext: false };
-    }
+    const parsed = parseOrNull(RawRecommendResponseSchema, res.data, `RecommendAPI/${recommendType}`);
+    if (!parsed) return { data: [], nextCursor: null, hasNext: false };
 
     return {
-      data: parsed.data.recommend_recipes.map(toRecommendRecipe),
-      nextCursor: parsed.data.next_cursor ?? null,
-      hasNext: parsed.data.has_next ?? false,
+      data: parsed.recommend_recipes.map(toRecommendRecipe),
+      nextCursor: parsed.next_cursor ?? null,
+      hasNext: parsed.has_next ?? false,
     };
   } catch (err: any) {
     console.error(`[RecommendAPI] ${recommendType} error:`, err?.response?.status, err?.message);

--- a/src/entities/recipe/api/search-api.ts
+++ b/src/entities/recipe/api/search-api.ts
@@ -1,31 +1,27 @@
 import { z } from 'zod';
-import { client } from '@/src/shared/api';
+import { client, parseOrNull } from '@/src/shared/api';
 
 // ─── Raw schemas ─────────────────────────────────────────────────
 
 const RawAutocompleteItemSchema = z
   .object({
     autocomplete: z.string().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawAutocompleteResponseSchema = z
   .object({
     autocompletes: z.array(RawAutocompleteItemSchema).default([]),
-  })
-  .passthrough();
+  });
 
 const RawSearchHistoryItemSchema = z
   .object({
     history: z.string().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawSearchHistoriesResponseSchema = z
   .object({
     recipe_search_histories: z.array(RawSearchHistoryItemSchema).default([]),
-  })
-  .passthrough();
+  });
 
 const RawSearchedRecipeSchema = z
   .object({
@@ -34,33 +30,30 @@ const RawSearchedRecipeSchema = z
     video_thumbnail_url: z.string().nullish(),
     video_type: z.enum(['SHORTS', 'NORMAL']).nullish(),
     channel_title: z.string().nullish(),
-    cook_time: z.number().nullish(),
     cooking_time: z.number().nullish(),
     servings: z.number().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawSearchResponseSchema = z
   .object({
     searched_recipes: z.array(RawSearchedRecipeSchema).default([]),
     next_cursor: z.string().nullish(),
     has_next: z.boolean().nullish(),
-  })
-  .passthrough();
+  });
 
 type RawSearchedRecipe = z.infer<typeof RawSearchedRecipeSchema>;
 
 // ─── Client types ────────────────────────────────────────────────
 
-export interface AutocompleteItem {
+export type AutocompleteItem = {
   text: string;
 }
 
-export interface SearchHistory {
+export type SearchHistory = {
   text: string;
 }
 
-export interface SearchedRecipe {
+export type SearchedRecipe = {
   recipeId: string;
   recipeTitle: string;
   videoThumbnailUrl: string;
@@ -70,7 +63,7 @@ export interface SearchedRecipe {
   servings: number;
 }
 
-export interface SearchResultPage {
+export type SearchResultPage = {
   data: SearchedRecipe[];
   nextCursor: string | null;
   hasNext: boolean;
@@ -85,7 +78,7 @@ function toSearchedRecipe(raw: RawSearchedRecipe): SearchedRecipe {
     videoThumbnailUrl: raw.video_thumbnail_url ?? '',
     videoType: raw.video_type ?? 'NORMAL',
     channelTitle: raw.channel_title ?? '',
-    cookingTime: raw.cook_time ?? raw.cooking_time ?? 0,
+    cookingTime: raw.cooking_time ?? 0,
     servings: raw.servings ?? 0,
   };
 }
@@ -95,12 +88,9 @@ function toSearchedRecipe(raw: RawSearchedRecipe): SearchedRecipe {
 export async function fetchAutocomplete(query: string): Promise<AutocompleteItem[]> {
   try {
     const res = await client.get('/search/autocomplete', { params: { query, scope: 'RECIPE' } });
-    const parsed = RawAutocompleteResponseSchema.safeParse(res.data);
-    if (!parsed.success) {
-      console.warn('[SearchAPI] autocomplete schema error:', parsed.error.issues);
-      return [];
-    }
-    return parsed.data.autocompletes
+    const parsed = parseOrNull(RawAutocompleteResponseSchema, res.data, 'SearchAPI/autocomplete');
+    if (!parsed) return [];
+    return parsed.autocompletes
       .map((i) => ({ text: i.autocomplete ?? '' }))
       .filter((i) => i.text.length > 0);
   } catch {
@@ -111,12 +101,9 @@ export async function fetchAutocomplete(query: string): Promise<AutocompleteItem
 export async function fetchSearchHistories(): Promise<SearchHistory[]> {
   try {
     const res = await client.get('/search/histories', { params: { scope: 'RECIPE' } });
-    const parsed = RawSearchHistoriesResponseSchema.safeParse(res.data);
-    if (!parsed.success) {
-      console.warn('[SearchAPI] histories schema error:', parsed.error.issues);
-      return [];
-    }
-    return parsed.data.recipe_search_histories
+    const parsed = parseOrNull(RawSearchHistoriesResponseSchema, res.data, 'SearchAPI/histories');
+    if (!parsed) return [];
+    return parsed.recipe_search_histories
       .map((i) => ({ text: i.history ?? '' }))
       .filter((i) => i.text.length > 0);
   } catch {
@@ -140,15 +127,12 @@ export async function searchRecipes(
     const res = await client.get('/recipes/search', {
       params: { query, ...(cursor ? { cursor } : {}) },
     });
-    const parsed = RawSearchResponseSchema.safeParse(res.data);
-    if (!parsed.success) {
-      console.warn('[SearchAPI] search schema error:', parsed.error.issues);
-      return { data: [], nextCursor: null, hasNext: false };
-    }
+    const parsed = parseOrNull(RawSearchResponseSchema, res.data, 'SearchAPI/search');
+    if (!parsed) return { data: [], nextCursor: null, hasNext: false };
     return {
-      data: parsed.data.searched_recipes.map(toSearchedRecipe),
-      nextCursor: parsed.data.next_cursor ?? null,
-      hasNext: parsed.data.has_next ?? false,
+      data: parsed.searched_recipes.map(toSearchedRecipe),
+      nextCursor: parsed.next_cursor ?? null,
+      hasNext: parsed.has_next ?? false,
     };
   } catch {
     return { data: [], nextCursor: null, hasNext: false };

--- a/src/entities/recipe/api/types.ts
+++ b/src/entities/recipe/api/types.ts
@@ -1,31 +1,31 @@
-export interface IngredientAmount {
+export type IngredientAmount = {
   value: number | null;
   unit: string | null;
 }
 
-export interface Ingredient {
+export type Ingredient = {
   name: string;
   amount: IngredientAmount;
   substitute?: string | null;
   selectionTip?: string | null;
 }
 
-export interface Tool {
+export type Tool = {
   name: string;
 }
 
-export interface Scene {
+export type Scene = {
   label: string;
   start: string;
   end: string;
 }
 
-export interface DescriptionItem {
+export type DescriptionItem = {
   content: string;
   start: string;
 }
 
-export interface Step {
+export type Step = {
   order: number;
   title: string;
   description: string | DescriptionItem[];
@@ -36,7 +36,7 @@ export interface Step {
   heatLevel?: string | null;
 }
 
-export interface Recipe {
+export type Recipe = {
   title: string;
   description: string | null;
   servings: number | null;
@@ -49,7 +49,7 @@ export interface Recipe {
   servingTip?: string | null;
 }
 
-export interface RecipeEntry {
+export type RecipeEntry = {
   recipe: Recipe;
   videoId: string;
   videoType?: 'SHORTS' | 'NORMAL';

--- a/src/entities/recipe/api/user-recipe-api.ts
+++ b/src/entities/recipe/api/user-recipe-api.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { client } from '@/src/shared/api';
+import { client, parseOrNull } from '@/src/shared/api';
 
 // ─── Raw schemas ─────────────────────────────────────────────────
 
@@ -12,50 +12,44 @@ const RawUserRecipeSchema = z
     video_type: z.enum(['SHORTS', 'NORMAL']).nullish(),
     channel_title: z.string().nullish(),
     cook_time: z.number().nullish(),
-    cooking_time: z.number().nullish(),
     servings: z.number().nullish(),
     description: z.string().nullish(),
     recipe_status: z.string().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawRecentRecipesResponseSchema = z
   .object({
     recent_recipes: z.array(RawUserRecipeSchema).default([]),
     next_cursor: z.string().nullish(),
     has_next: z.boolean().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawCategorizedRecipesResponseSchema = z
   .object({
     categorized_recipes: z.array(RawUserRecipeSchema).default([]),
     next_cursor: z.string().nullish(),
     has_next: z.boolean().nullish(),
-  })
-  .passthrough();
+  });
 
 const RawCategorySchema = z
   .object({
     category_id: z.string(),
     name: z.string(),
     count: z.number().default(0),
-  })
-  .passthrough();
+  });
 
 const RawCategoriesResponseSchema = z
   .object({
     categories: z.array(RawCategorySchema).default([]),
     total_count: z.number().nullish(),
-  })
-  .passthrough();
+  });
 
 type RawUserRecipe = z.infer<typeof RawUserRecipeSchema>;
 type RawCategory = z.infer<typeof RawCategorySchema>;
 
 // ─── Client types ────────────────────────────────────────────────
 
-export interface UserRecipe {
+export type UserRecipe = {
   recipeId: string;
   recipeTitle: string;
   videoId: string;
@@ -68,13 +62,13 @@ export interface UserRecipe {
   recipeStatus: string;
 }
 
-export interface Category {
+export type Category = {
   categoryId: string;
   name: string;
   count: number;
 }
 
-export interface UserRecipesPage {
+export type UserRecipesPage = {
   data: UserRecipe[];
   nextCursor: string | null;
   hasNext: boolean;
@@ -90,7 +84,7 @@ function toUserRecipe(raw: RawUserRecipe): UserRecipe {
     videoThumbnailUrl: raw.video_thumbnail_url ?? '',
     videoType: raw.video_type ?? 'NORMAL',
     channelTitle: raw.channel_title ?? '',
-    cookingTime: raw.cook_time ?? raw.cooking_time ?? 0,
+    cookingTime: raw.cook_time ?? 0,
     servings: raw.servings ?? 0,
     description: raw.description ?? '',
     recipeStatus: raw.recipe_status ?? '',
@@ -110,15 +104,12 @@ function toCategory(raw: RawCategory): Category {
 export async function fetchMyRecipes(cursor?: string | null): Promise<UserRecipesPage> {
   try {
     const res = await client.get('/recipes/recent', { params: cursor ? { cursor } : {} });
-    const parsed = RawRecentRecipesResponseSchema.safeParse(res.data);
-    if (!parsed.success) {
-      console.warn('[UserRecipeAPI] my recipes schema error:', parsed.error.issues);
-      return { data: [], nextCursor: null, hasNext: false };
-    }
+    const parsed = parseOrNull(RawRecentRecipesResponseSchema, res.data, 'UserRecipeAPI/my');
+    if (!parsed) return { data: [], nextCursor: null, hasNext: false };
     return {
-      data: parsed.data.recent_recipes.map(toUserRecipe),
-      nextCursor: parsed.data.next_cursor ?? null,
-      hasNext: parsed.data.has_next ?? false,
+      data: parsed.recent_recipes.map(toUserRecipe),
+      nextCursor: parsed.next_cursor ?? null,
+      hasNext: parsed.has_next ?? false,
     };
   } catch (err: any) {
     console.warn('[UserRecipeAPI] fetchMyRecipes error:', err?.response?.status, err?.message);
@@ -134,15 +125,12 @@ export async function fetchCategorizedRecipes(
     const res = await client.get(`/recipes/categorized/${categoryId}`, {
       params: cursor ? { cursor } : {},
     });
-    const parsed = RawCategorizedRecipesResponseSchema.safeParse(res.data);
-    if (!parsed.success) {
-      console.warn('[UserRecipeAPI] categorized schema error:', parsed.error.issues);
-      return { data: [], nextCursor: null, hasNext: false };
-    }
+    const parsed = parseOrNull(RawCategorizedRecipesResponseSchema, res.data, 'UserRecipeAPI/categorized');
+    if (!parsed) return { data: [], nextCursor: null, hasNext: false };
     return {
-      data: parsed.data.categorized_recipes.map(toUserRecipe),
-      nextCursor: parsed.data.next_cursor ?? null,
-      hasNext: parsed.data.has_next ?? false,
+      data: parsed.categorized_recipes.map(toUserRecipe),
+      nextCursor: parsed.next_cursor ?? null,
+      hasNext: parsed.has_next ?? false,
     };
   } catch (err: any) {
     console.warn('[UserRecipeAPI] fetchCategorizedRecipes error:', err?.response?.status, err?.message);
@@ -153,12 +141,9 @@ export async function fetchCategorizedRecipes(
 export async function fetchCategories(): Promise<Category[]> {
   try {
     const res = await client.get('/recipes/categories');
-    const parsed = RawCategoriesResponseSchema.safeParse(res.data);
-    if (!parsed.success) {
-      console.warn('[UserRecipeAPI] categories schema error:', parsed.error.issues);
-      return [];
-    }
-    return parsed.data.categories.map(toCategory);
+    const parsed = parseOrNull(RawCategoriesResponseSchema, res.data, 'UserRecipeAPI/categories');
+    if (!parsed) return [];
+    return parsed.categories.map(toCategory);
   } catch (err: any) {
     console.warn('[UserRecipeAPI] fetchCategories error:', err?.response?.status, err?.message);
     return [];

--- a/src/entities/theme/api/theme-api.ts
+++ b/src/entities/theme/api/theme-api.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { parseOrNull } from '@/src/shared/api';
 import type { ThemeData, ThemeDish, DishTags, ThemeCategory } from './types';
 import { extractYoutubeVideoId } from './types';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -22,8 +23,7 @@ const RawDishTagsSchema = z
     style: z.array(z.string()).default([]),
     ingredient_focus: z.array(z.string()).default([]),
     budget: z.string(),
-  })
-  .passthrough();
+  });
 
 const RawThemeDishSchema = z
   .object({
@@ -41,8 +41,7 @@ const RawThemeDishSchema = z
     thumbnail: z.string().optional(),
     dish_name: z.string().optional(),
     failed: z.boolean().optional(),
-  })
-  .passthrough();
+  });
 
 const RawThemeCategorySchema = z
   .object({
@@ -51,8 +50,7 @@ const RawThemeCategorySchema = z
     emoji: z.string().default(''),
     concept: z.string().default(''),
     hook: z.string().optional(),
-  })
-  .passthrough();
+  });
 
 const RawThemeSchema = z
   .object({
@@ -64,14 +62,12 @@ const RawThemeSchema = z
     curator_quote: z.string().optional(),
     categories: z.array(RawThemeCategorySchema).optional(),
     dishes: z.array(RawThemeDishSchema).default([]),
-  })
-  .passthrough();
+  });
 
 const RawThemesResponseSchema = z
   .object({
     themes: z.array(RawThemeSchema).default([]),
-  })
-  .passthrough();
+  });
 
 // ─── Transformer ───
 
@@ -122,12 +118,9 @@ function toTheme(raw: z.infer<typeof RawThemeSchema>): ThemeData {
 export async function fetchThemes(): Promise<ThemeData[]> {
   if (!__DEV__ && cachedThemes) return cachedThemes;
 
-  const parsed = RawThemesResponseSchema.safeParse(themesJson);
-  if (!parsed.success) {
-    console.warn('[ThemeAPI] schema error:', JSON.stringify(parsed.error.issues, null, 2));
-    return [];
-  }
-  const themes = parsed.data.themes.map(toTheme);
+  const parsed = parseOrNull(RawThemesResponseSchema, themesJson, 'ThemeAPI');
+  if (!parsed) return [];
+  const themes = parsed.themes.map(toTheme);
   if (!__DEV__) cachedThemes = themes;
   console.log('[ThemeAPI] loaded themes:', themes.map(t => ({
     id: t.id,

--- a/src/entities/theme/api/types.ts
+++ b/src/entities/theme/api/types.ts
@@ -63,7 +63,7 @@ export type DishIngredientFocus =
 
 export type DishBudget = '가성비' | '보통' | '프리미엄';
 
-export interface DishTags {
+export type DishTags = {
   mood: DishMood[];
   difficulty: DishDifficulty;
   time: DishTime;
@@ -82,7 +82,7 @@ export interface DishTags {
 
 export type DishCategoryId = string;
 
-export interface ThemeCategory {
+export type ThemeCategory = {
   id: DishCategoryId;           // ex: "boyfriend", "girlfriend", "lunchbox"
   name: string;                 // 8자 이내 표시명. ex: "남친한테"
   emoji: string;                // ex: "💪"
@@ -92,7 +92,7 @@ export interface ThemeCategory {
 
 // ─── Dish (큐레이션 영상 단위) ───
 
-export interface ThemeDish {
+export type ThemeDish = {
   id: string;                   // 클라이언트 키 (예: "love-1")
   title: string;
   channel: string;
@@ -112,7 +112,7 @@ export interface ThemeDish {
 
 // ─── Theme ───
 
-export interface ThemeData {
+export type ThemeData = {
   id: string;
   title: string;
   subtitle: string;

--- a/src/entities/user/api/auth-api.ts
+++ b/src/entities/user/api/auth-api.ts
@@ -1,7 +1,7 @@
 import { client } from '@/src/shared/api';
 import type { LoginInfo, SignupData, AuthResponse, UserResponse } from './types';
 
-interface RawUserResponse {
+type RawUserResponse = {
   provider_sub: string;
   gender: any;
   nickname: string;
@@ -11,7 +11,7 @@ interface RawUserResponse {
   terms_of_use_agreed_at: string | null;
 }
 
-interface RawAuthResponse {
+type RawAuthResponse = {
   access_token: string;
   refresh_token: string;
   user_info: RawUserResponse;

--- a/src/entities/user/api/types.ts
+++ b/src/entities/user/api/types.ts
@@ -5,12 +5,12 @@ import type { DateOnly } from '@/src/shared/utils/dateOnly';
 export type { Gender } from './gender';
 export type { OauthProvider } from './oauth-provider';
 
-export interface LoginInfo {
+export type LoginInfo = {
   id_token: string;
   provider: OauthProvider;
 }
 
-export interface SignupData {
+export type SignupData = {
   id_token: string;
   provider: OauthProvider;
   nickname: string;
@@ -21,7 +21,7 @@ export interface SignupData {
   is_terms_of_use_agreed: boolean;
 }
 
-export interface UserResponse {
+export type UserResponse = {
   provider_sub: string;
   gender: Gender | null;
   nickname: string;
@@ -31,7 +31,7 @@ export interface UserResponse {
   is_terms_of_use_agreed: boolean;
 }
 
-export interface AuthResponse {
+export type AuthResponse = {
   access_token: string;
   refresh_token: string;
   user_info: UserResponse;

--- a/src/entities/user/api/user-api.ts
+++ b/src/entities/user/api/user-api.ts
@@ -2,7 +2,7 @@ import { client } from '@/src/shared/api';
 import { DateOnly } from '@/src/shared/utils/dateOnly';
 import type { Gender } from './gender';
 
-export interface MeResponse {
+export type MeResponse = {
   provider_sub: string;
   gender: Gender | null;
   nickname: string;
@@ -12,7 +12,7 @@ export interface MeResponse {
   is_terms_of_use_agreed: boolean;
 }
 
-interface RawMeResponse {
+type RawMeResponse = {
   provider_sub: string;
   gender: Gender | null;
   nickname: string;

--- a/src/entities/user/hooks/use-delete-account.ts
+++ b/src/entities/user/hooks/use-delete-account.ts
@@ -4,7 +4,7 @@ import { useUserStore } from '../store/user-store';
 import { findRefreshToken, clearTokens, useAuthStore } from '@/src/shared/api';
 import { unregisterExpoPushOnLogout } from '@/src/modules/notifications/expo-push';
 
-interface UseDeleteAccountOptions {
+type UseDeleteAccountOptions = {
   onSuccess?: () => void;
   onError?: (error: Error) => void;
 }

--- a/src/entities/user/hooks/use-login.ts
+++ b/src/entities/user/hooks/use-login.ts
@@ -6,7 +6,7 @@ import { storeTokens, useAuthStore } from '@/src/shared/api';
 import { DateOnly } from '@/src/shared/utils/dateOnly';
 import type { AuthResponse, LoginInfo } from '../api/types';
 
-interface UseLoginOptions {
+type UseLoginOptions = {
   onSuccess?: (data: AuthResponse, variables: LoginInfo) => void;
   onError?: (error: Error, variables: LoginInfo) => void;
 }

--- a/src/entities/user/hooks/use-logout.ts
+++ b/src/entities/user/hooks/use-logout.ts
@@ -4,7 +4,7 @@ import { useUserStore } from '../store/user-store';
 import { findRefreshToken, clearTokens, useAuthStore } from '@/src/shared/api';
 import { unregisterExpoPushOnLogout } from '@/src/modules/notifications/expo-push';
 
-interface UseLogoutOptions {
+type UseLogoutOptions = {
   onSuccess?: () => void;
   onError?: (error: Error) => void;
   onSettled?: () => void;

--- a/src/entities/user/hooks/use-signup.ts
+++ b/src/entities/user/hooks/use-signup.ts
@@ -6,7 +6,7 @@ import { storeTokens, useAuthStore } from '@/src/shared/api';
 import { DateOnly } from '@/src/shared/utils/dateOnly';
 import type { AuthResponse, SignupData } from '../api/types';
 
-interface UseSignupOptions {
+type UseSignupOptions = {
   onSuccess?: (data: AuthResponse, variables: SignupData) => void;
   onError?: (error: Error, variables: SignupData) => void;
 }

--- a/src/entities/user/store/user-store.ts
+++ b/src/entities/user/store/user-store.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { User } from '../model/user';
 
-interface UserStore {
+type UserStore = {
   user: User | null;
   setUser: (user: User) => void;
   removeUser: () => void;

--- a/src/locales/privacyPolicy.ts
+++ b/src/locales/privacyPolicy.ts
@@ -1,11 +1,11 @@
 import type { Market } from "@/src/shared/types/market";
 
-export interface PrivacyPolicyDetail {
+export type PrivacyPolicyDetail = {
   letter: string;
   content: string;
 }
 
-export interface PrivacyPolicySubsection {
+export type PrivacyPolicySubsection = {
   number: number;
   content: string;
   details?: PrivacyPolicyDetail[];
@@ -17,7 +17,7 @@ export interface PrivacyPolicySubsection {
   additionalInfo?: string;
 }
 
-export interface PrivacyPolicyCategory {
+export type PrivacyPolicyCategory = {
   category: string;
   items: Array<{
     detail: string;
@@ -25,7 +25,7 @@ export interface PrivacyPolicyCategory {
   }>;
 }
 
-export interface PrivacyPolicySection {
+export type PrivacyPolicySection = {
   article: number;
   title: string;
   content?: string;
@@ -41,7 +41,7 @@ export interface PrivacyPolicySection {
   };
 }
 
-export interface PrivacyPolicyData {
+export type PrivacyPolicyData = {
   title: string;
   effectiveDate: string;
   effectiveDatePrefix: string;

--- a/src/locales/termsOfService.ts
+++ b/src/locales/termsOfService.ts
@@ -1,24 +1,24 @@
 import type { Market } from "@/src/shared/types/market";
 
-export interface TermsOfServiceDetail {
+export type TermsOfServiceDetail = {
   letter: string;
   content: string;
 }
 
-export interface TermsOfServiceSubsection {
+export type TermsOfServiceSubsection = {
   number: number;
   content: string;
   details?: TermsOfServiceDetail[];
 }
 
-export interface TermsOfServiceSection {
+export type TermsOfServiceSection = {
   article: number;
   title: string;
   content?: string;
   subsections?: TermsOfServiceSubsection[];
 }
 
-export interface TermsOfServiceData {
+export type TermsOfServiceData = {
   title: string;
   effectiveDate: string;
   effectiveDatePrefix: string;

--- a/src/pages/bookmark/components/category-chips.tsx
+++ b/src/pages/bookmark/components/category-chips.tsx
@@ -1,7 +1,7 @@
 import { Pressable, ScrollView, Text, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { colors, spacing, radius } from '@/src/shared/design/tokens';
-interface CategoryChipsProps {
+type CategoryChipsProps = {
   categories: { id: string; name: string }[];
   selected: string;
   onSelect: (id: string) => void;

--- a/src/pages/bookmark/components/recipe-grid.tsx
+++ b/src/pages/bookmark/components/recipe-grid.tsx
@@ -14,7 +14,7 @@ import Animated, {
 import { colors, spacing, radius, typography } from '@/src/shared/design/tokens';
 import type { RecipeCard } from '@/src/shared/data/mock';
 
-interface RecipeGridProps {
+type RecipeGridProps = {
   recipes: RecipeCard[];
   onPress: (recipe: RecipeCard) => void;
   onLongPress: (recipe: RecipeCard) => void;

--- a/src/pages/home/components/feature-cards.tsx
+++ b/src/pages/home/components/feature-cards.tsx
@@ -9,7 +9,7 @@ const CARD_IMAGES = {
   calendar: require('@/assets/images/card-calendar.png'),
 };
 
-interface FeatureCard {
+type FeatureCard = {
   id: keyof typeof CARD_IMAGES;
   title: string;
   subtitle: string;
@@ -23,7 +23,7 @@ const FEATURES: FeatureCard[] = [
   { id: 'calendar', title: '캘린더', subtitle: '', backgroundColor: colors.card.calendar, locked: true },
 ];
 
-interface FeatureCardsProps {
+type FeatureCardsProps = {
   onCreatePress: () => void;
   onLockedPress: (feature: string) => void;
 }

--- a/src/pages/home/components/home-header.tsx
+++ b/src/pages/home/components/home-header.tsx
@@ -7,7 +7,7 @@ import { useBalance } from '@/src/entities/balance';
 
 const BERRY_ICON = require('@/assets/images/berry-icon.png');
 
-interface HomeHeaderProps {
+type HomeHeaderProps = {
   onBerryPress: () => void;
   onSearchPress: () => void;
   onSettingsPress: () => void;

--- a/src/pages/home/components/recipe-create-sheet.tsx
+++ b/src/pages/home/components/recipe-create-sheet.tsx
@@ -28,7 +28,7 @@ function extractVideoId(url: string): string | null {
   return null;
 }
 
-export interface RecipeCreateSheetRef {
+export type RecipeCreateSheetRef = {
   open: (initialUrl?: string) => void;
   close: () => void;
 }

--- a/src/pages/home/components/recipe-section.tsx
+++ b/src/pages/home/components/recipe-section.tsx
@@ -8,7 +8,7 @@ import type { RecipeCard, ThemeCard } from '@/src/shared/data/mock';
 import { useRecipeCreateStore } from '@/src/pages/home/model/recipe-create-store';
 import { useRecipeProgress, RecipeStatus } from '@/src/entities/recipe';
 
-interface ThemeCardsSectionProps {
+type ThemeCardsSectionProps = {
   cards: ThemeCard[];
   onPress: (card: ThemeCard) => void;
 }
@@ -116,7 +116,7 @@ export function ThemeCardsSection({ cards, onPress }: ThemeCardsSectionProps) {
   );
 }
 
-interface RecentRecipeSectionProps {
+type RecentRecipeSectionProps = {
   recipes: RecipeCard[];
   onPress: (recipe: RecipeCard) => void;
 }
@@ -345,7 +345,7 @@ function CreatingRecipeCard({ recipeId }: { recipeId: string }) {
   );
 }
 
-interface RecipeListSectionProps {
+type RecipeListSectionProps = {
   title: string;
   icon?: string;
   recipes: RecipeCard[];

--- a/src/pages/home/model/recipe-create-store.ts
+++ b/src/pages/home/model/recipe-create-store.ts
@@ -1,12 +1,12 @@
 import { create } from 'zustand';
 
-interface CreatingRecipe {
+type CreatingRecipe = {
   recipeId: string;
   videoUrl: string;
   startedAt: number;
 }
 
-interface RecipeCreateStore {
+type RecipeCreateStore = {
   /** 딥링크로 받은 URL — 다음 마운트 시 시트 자동 오픈 */
   pendingVideoUrl: string | null;
   requestOpen: (videoUrl?: string) => void;

--- a/src/pages/home/ui/home-screen.tsx
+++ b/src/pages/home/ui/home-screen.tsx
@@ -32,7 +32,7 @@ function toRecipeCards(data: any[] | undefined): RecipeCard[] {
   }));
 }
 
-interface HomeScreenProps {
+type HomeScreenProps = {
   onCreatePress?: () => void;
 }
 

--- a/src/pages/login/ui/TermsAndConditionsModalContent.tsx
+++ b/src/pages/login/ui/TermsAndConditionsModalContent.tsx
@@ -13,7 +13,7 @@ import useRandomName from "@/src/pages/login/model/useRandomName";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useMarketStore } from "@/src/shared/store/marketStore";
 
-export interface AgreeValue {
+export type AgreeValue = {
   isServiceAgree: boolean;
   isPrivacyAgree: boolean;
   isMarketingAgree: boolean;

--- a/src/pages/native-step/components/IntentFeedbackToast.tsx
+++ b/src/pages/native-step/components/IntentFeedbackToast.tsx
@@ -12,7 +12,7 @@ import Animated, {
   withSequence,
 } from 'react-native-reanimated';
 
-interface IntentFeedbackToastProps {
+type IntentFeedbackToastProps = {
   message: string | null;
 }
 

--- a/src/pages/native-step/components/PawFeedback.tsx
+++ b/src/pages/native-step/components/PawFeedback.tsx
@@ -11,7 +11,7 @@ import Animated, {
 
 const PAW_IMAGE = require('@/assets/images/paw-print.png');
 
-interface PawFeedbackProps {
+type PawFeedbackProps = {
   visible: boolean;
   onDone?: () => void;
   size?: number;

--- a/src/pages/native-step/components/SpeechCaptionBar.tsx
+++ b/src/pages/native-step/components/SpeechCaptionBar.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import type { PipelineState } from '../hooks/useAudioPipeline';
 
-interface SpeechCaptionBarProps {
+type SpeechCaptionBarProps = {
   isListening: boolean;
   transcript: string;
   pipelineState: PipelineState;

--- a/src/pages/native-step/components/TimerBottomSheet.tsx
+++ b/src/pages/native-step/components/TimerBottomSheet.tsx
@@ -126,12 +126,12 @@ export function TimerMiniBar({
 }
 
 // ─── 바텀시트 ───
-export interface TimerSheetRef {
+export type TimerSheetRef = {
   open: () => void;
   close: () => void;
 }
 
-interface TimerBottomSheetProps {
+type TimerBottomSheetProps = {
   timerResult: StepTimerResult;
   stepName: string;
 }

--- a/src/pages/native-step/hooks/onnxEmbedding.ts
+++ b/src/pages/native-step/hooks/onnxEmbedding.ts
@@ -13,14 +13,14 @@ import { Asset } from 'expo-asset';
 let _instance: EmbeddingInstance | null = null;
 let _loading: Promise<EmbeddingInstance> | null = null;
 
-export interface EmbeddingInstance {
+export type EmbeddingInstance = {
   embed: (text: string) => Promise<number[] | null>;
   dispose: () => Promise<void>;
 }
 
 // ─── Unigram (SentencePiece) Tokenizer ───
 
-interface UnigramTokenizerJSON {
+type UnigramTokenizerJSON = {
   model: {
     type: string;
     vocab: [string, number][];

--- a/src/pages/native-step/hooks/onnxNLU.ts
+++ b/src/pages/native-step/hooks/onnxNLU.ts
@@ -33,7 +33,7 @@ const ID2LABEL: Record<number, IntentLabel> = {
   6: 'GO_TO_SCENE',
 };
 
-export interface NLUResult {
+export type NLUResult = {
   intent: IntentLabel;
   confidence: number;
   allScores: Record<IntentLabel, number>;
@@ -41,7 +41,7 @@ export interface NLUResult {
 
 // ─── WordPiece Tokenizer ───
 
-interface TokenizerJSON {
+type TokenizerJSON = {
   model: {
     type: string;
     vocab: Record<string, number>;
@@ -136,7 +136,7 @@ class WordPieceTokenizer {
 let _instance: NLUInstance | null = null;
 let _loading: Promise<NLUInstance> | null = null;
 
-interface NLUInstance {
+type NLUInstance = {
   classify: (text: string) => Promise<NLUResult | null>;
   dispose: () => Promise<void>;
 }

--- a/src/pages/native-step/hooks/sileroVAD.ts
+++ b/src/pages/native-step/hooks/sileroVAD.ts
@@ -14,7 +14,7 @@ import { Asset } from 'expo-asset';
 export const SAMPLE_RATE = 16000;
 export const WINDOW_SIZE = 512; // Silero VAD v4: 512 samples = 32ms @ 16kHz
 
-export interface SileroVADInstance {
+export type SileroVADInstance = {
   process: (frame: Float32Array) => Promise<number>;
   reset: () => void;
   dispose: () => void;

--- a/src/pages/native-step/hooks/useAudioPipeline.ts
+++ b/src/pages/native-step/hooks/useAudioPipeline.ts
@@ -10,7 +10,7 @@
 
 export type PipelineState = 'IDLE' | 'LISTENING' | 'TRANSCRIBING';
 
-export interface AudioPipelineResult {
+export type AudioPipelineResult = {
   state: PipelineState;
   start: () => Promise<void>;
   stop: () => void;

--- a/src/pages/native-step/hooks/useLocalNLU.ts
+++ b/src/pages/native-step/hooks/useLocalNLU.ts
@@ -18,13 +18,13 @@
 
 import type { IntentLabel } from './onnxNLU';
 
-export interface LocalNLUPayload {
+export type LocalNLUPayload = {
   stepNumber?: number;
   sceneNumber?: number;
   durationSec?: number;
 }
 
-export interface LocalNLUResult {
+export type LocalNLUResult = {
   intent: IntentLabel;
   payload: LocalNLUPayload;
 }
@@ -117,7 +117,7 @@ function findInWindow(
   return window.match(slotRe);
 }
 
-interface Slots {
+type Slots = {
   timerDurationSec?: number;  // 0 = 숫자 없는 타이머 명령(취소/멈춤 등)
   hasTimerAnchor: boolean;
   stepNumber?: number;

--- a/src/pages/native-step/hooks/useSceneMatcher.ts
+++ b/src/pages/native-step/hooks/useSceneMatcher.ts
@@ -8,7 +8,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createEmbedding, cosineSimilarity, type EmbeddingInstance } from './onnxEmbedding';
 
-export interface SceneMatchResult {
+export type SceneMatchResult = {
   index: number;
   score: number;
   label: string;

--- a/src/pages/native-step/hooks/useStepTimer.ts
+++ b/src/pages/native-step/hooks/useStepTimer.ts
@@ -15,7 +15,7 @@ import { useMarketStore } from '@/src/shared/store/marketStore';
 
 export type TimerState = 'IDLE' | 'ACTIVE' | 'PAUSED' | 'FINISHED';
 
-export interface Timer {
+export type Timer = {
   id: string;
   name: string;
   duration: number;        // 총 시간 (초)
@@ -25,7 +25,7 @@ export interface Timer {
 }
 
 // ─── Zustand Store ───
-interface TimerStore {
+type TimerStore = {
   timer: Timer | null;
   isSheetOpen: boolean;
 
@@ -137,7 +137,7 @@ export function dismissFinishedAction() {
 }
 
 // ─── Hook (컴포넌트에서 사용) ───
-export interface StepTimerResult {
+export type StepTimerResult = {
   timer: Timer | null;
   displayTime: string;
   progress: number;

--- a/src/pages/native-step/hooks/useVoiceCommand.ts
+++ b/src/pages/native-step/hooks/useVoiceCommand.ts
@@ -32,7 +32,7 @@ import { useSceneMatcher } from './useSceneMatcher';
 
 const NLU_CONFIDENCE_THRESHOLD = 0.7;
 
-interface UseVoiceCommandOptions {
+type UseVoiceCommandOptions = {
   goToNextStep: () => void;
   goToPrevStep: () => void;
   goToStep: (stepNumber: number) => void;

--- a/src/pages/native-step/hooks/useWebAudioPipeline.ts
+++ b/src/pages/native-step/hooks/useWebAudioPipeline.ts
@@ -108,7 +108,7 @@ class RingBuffer {
 }
 
 // ─── Hook ───
-interface UseWebAudioPipelineOptions {
+type UseWebAudioPipelineOptions = {
   onInterimResult: (text: string) => void;
   onFinalResult: (text: string) => void;
   onVoiceStart?: () => void;
@@ -117,7 +117,7 @@ interface UseWebAudioPipelineOptions {
   webViewRef: React.RefObject<WebView | null>;
 }
 
-export interface WebAudioPipelineResult extends AudioPipelineResult {
+export type WebAudioPipelineResult = AudioPipelineResult & {
   handleWebViewMessage: (event: WebViewMessageEvent) => void;
   vadSpeechStartRef: React.RefObject<number>;
 }

--- a/src/pages/native-step/ui/RecipeStepScreen.tsx
+++ b/src/pages/native-step/ui/RecipeStepScreen.tsx
@@ -40,18 +40,18 @@ const INJECTED_JS_BRIDGE = `
   })();
 `;
 
-interface DescriptionItem {
+type DescriptionItem = {
   content: string;
   start?: string;
 }
 
-interface Scene {
+type Scene = {
   label: string;
   start: string;
   end: string;
 }
 
-interface RecipeStepScreenProps {
+type RecipeStepScreenProps = {
   videoId: string;
   recipe: any;
   isShorts?: boolean;

--- a/src/pages/onboarding/ui/onboarding-screen.tsx
+++ b/src/pages/onboarding/ui/onboarding-screen.tsx
@@ -30,7 +30,7 @@ const APP_DETAIL_2_1 = require('@/assets/images/onboarding/app-detail-2_1.png');
 const APP_DETAIL_2_2 = require('@/assets/images/onboarding/app-detail-2_2.png');
 const APP_COOKING = require('@/assets/images/onboarding/app-cooking_home.png');
 
-interface OnboardingScreenProps {
+type OnboardingScreenProps = {
   onComplete: () => void;
 }
 

--- a/src/pages/recipe-detail/ui/recipe-detail-screen.tsx
+++ b/src/pages/recipe-detail/ui/recipe-detail-screen.tsx
@@ -17,7 +17,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Alert } from 'react-native';
 import { track, RecipeDetailEvents, RecipeEnrollEvents } from '@/src/shared/analytics';
 
-interface RecipeDetailScreenProps {
+type RecipeDetailScreenProps = {
   recipeId: string;
 }
 

--- a/src/pages/theme/components/category-selector-sheet.tsx
+++ b/src/pages/theme/components/category-selector-sheet.tsx
@@ -9,12 +9,12 @@ import { typography, spacing, radius } from '@/src/shared/design/tokens';
 import type { ThemeCategory } from '@/src/entities/theme';
 import { getCategoryImage } from './category-images';
 
-export interface CategorySelectorSheetRef {
+export type CategorySelectorSheetRef = {
   open: () => void;
   close: () => void;
 }
 
-interface CategorySelectorSheetProps {
+type CategorySelectorSheetProps = {
   themeId: string;
   categories: ThemeCategory[];
   themeColor: string;

--- a/src/pages/theme/components/dish-list-card.tsx
+++ b/src/pages/theme/components/dish-list-card.tsx
@@ -8,7 +8,7 @@ import { colors, radius, typography } from '@/src/shared/design/tokens';
 import { type ThemeDish, youtubeThumbnailUrl } from '@/src/entities/theme';
 import { track, ThemeEvents } from '@/src/shared/analytics';
 
-interface DishListCardProps {
+type DishListCardProps = {
   dish: ThemeDish;
   isDark: boolean;
   themeId?: string;

--- a/src/pages/theme/components/filter-chip.tsx
+++ b/src/pages/theme/components/filter-chip.tsx
@@ -1,7 +1,7 @@
 import { Pressable, Text } from 'react-native';
 import { colors, radius, typography } from '@/src/shared/design/tokens';
 
-interface FilterChipProps {
+type FilterChipProps = {
   label: string;
   active: boolean;
   isDark: boolean;

--- a/src/pages/theme/components/mood-selector-sheet.tsx
+++ b/src/pages/theme/components/mood-selector-sheet.tsx
@@ -5,12 +5,12 @@ import BottomSheet, { BottomSheetView, BottomSheetBackdrop, BottomSheetScrollVie
 import { typography, spacing, radius } from '@/src/shared/design/tokens';
 import { getMoodImage } from './mood-images';
 
-export interface MoodSelectorSheetRef {
+export type MoodSelectorSheetRef = {
   open: () => void;
   close: () => void;
 }
 
-interface MoodSelectorSheetProps {
+type MoodSelectorSheetProps = {
   moods: string[];
   themeColor: string;
   themeTitle: string;

--- a/src/pages/theme/components/theme-banner.tsx
+++ b/src/pages/theme/components/theme-banner.tsx
@@ -5,7 +5,7 @@ import type { ThemeData, ThemeCategory } from '@/src/entities/theme';
 import { THEME_IMAGES } from './theme-images';
 import { getCategoryImage } from './category-images';
 
-interface ThemeBannerProps {
+type ThemeBannerProps = {
   theme: ThemeData;
   /** 카테고리가 선택된 상태면 히어로를 카테고리 컨셉으로 교체 */
   selectedCategory?: ThemeCategory | null;

--- a/src/pages/theme/ui/theme-detail-screen.tsx
+++ b/src/pages/theme/ui/theme-detail-screen.tsx
@@ -9,7 +9,7 @@ import { MoodSelectorSheet, type MoodSelectorSheetRef } from '../components/mood
 import { CategorySelectorSheet, type CategorySelectorSheetRef } from '../components/category-selector-sheet';
 import { track, ThemeEvents } from '@/src/shared/analytics';
 
-interface ThemeDetailScreenProps {
+type ThemeDetailScreenProps = {
   theme: ThemeData;
 }
 

--- a/src/shared/analytics/track.ts
+++ b/src/shared/analytics/track.ts
@@ -45,7 +45,7 @@ export type AmplitudeEventName =
  * 이벤트별 프로퍼티 타입 매핑.
  * 웹뷰(`webview-v2`)와 동일한 이름/타입을 유지 → funnel 공유.
  */
-export interface EventPropsMap {
+export type EventPropsMap = {
   // ─── Auth (네이티브 전용) ───
   [AuthEvents.LOGIN_SUCCESS]: { provider: string };
   [AuthEvents.SIGNUP_SUCCESS]: { provider: string };

--- a/src/shared/api/auth-store.ts
+++ b/src/shared/api/auth-store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-interface AuthState {
+type AuthState = {
   isAuthenticated: boolean;
   setAuthenticated: () => void;
   clearAuth: () => void;

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -7,3 +7,4 @@ export {
 } from './secure-storage';
 export { useAuthStore } from './auth-store';
 export { refreshToken } from './refresh-token';
+export { parseOrNull, parseOrFallback } from './parse';

--- a/src/shared/api/reissue-api.ts
+++ b/src/shared/api/reissue-api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-interface ReissueResponse {
+type ReissueResponse = {
   access_token: string;
   refresh_token: string;
 }

--- a/src/shared/components/error/ApiErrorBoundary.tsx
+++ b/src/shared/components/error/ApiErrorBoundary.tsx
@@ -2,7 +2,7 @@ import { QueryErrorResetBoundary } from "@tanstack/react-query";
 import * as Sentry from "@sentry/react-native";
 import React from "react";
 
-interface Props {
+type Props = {
   children: React.ReactNode;
   fallbackComponent: React.ComponentType<any>;
 }

--- a/src/shared/components/error/Fallback.tsx
+++ b/src/shared/components/error/Fallback.tsx
@@ -1,7 +1,7 @@
 import { View, Text, TouchableOpacity } from "react-native";
 import { errorStyles } from "@/src/shared/styles/error";
 
-interface GlobalErrorProps {
+type GlobalErrorProps = {
   error?: Error;
   resetErrorBoundary: () => void;
 }

--- a/src/shared/components/error/GlobalErrorBoundary.tsx
+++ b/src/shared/components/error/GlobalErrorBoundary.tsx
@@ -4,7 +4,7 @@ import * as Sentry from "@sentry/react-native";
 import React from "react";
 import { AxiosError } from "axios";
 
-interface Props {
+type Props = {
   children: React.ReactNode;
 }
 

--- a/src/shared/components/floating-tab-bar.tsx
+++ b/src/shared/components/floating-tab-bar.tsx
@@ -3,7 +3,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { radius, spacing } from '@/src/shared/design/tokens';
 
-interface Tab {
+type Tab = {
   key: string;
   icon: keyof typeof MaterialCommunityIcons.glyphMap;
   iconActive: keyof typeof MaterialCommunityIcons.glyphMap;
@@ -14,7 +14,7 @@ const TABS: Tab[] = [
   { key: 'bookmark', icon: 'bookmark-outline', iconActive: 'bookmark' },
 ];
 
-interface FloatingTabBarProps {
+type FloatingTabBarProps = {
   activeTab: string;
   onTabPress: (key: string) => void;
 }

--- a/src/shared/components/pressable-card.tsx
+++ b/src/shared/components/pressable-card.tsx
@@ -9,7 +9,7 @@ import Animated, {
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
-interface PressableCardProps extends PressableProps {
+type PressableCardProps = PressableProps & {
   hapticIntensity?: 'light' | 'medium' | 'none';
   scaleTo?: number;
 }

--- a/src/shared/components/skeleton.tsx
+++ b/src/shared/components/skeleton.tsx
@@ -9,7 +9,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import { colors, radius } from '@/src/shared/design/tokens';
 
-interface SkeletonProps {
+type SkeletonProps = {
   width: number | string;
   height: number;
   borderRadius?: number;

--- a/src/shared/components/tory-empty-state.tsx
+++ b/src/shared/components/tory-empty-state.tsx
@@ -18,7 +18,7 @@ const TORY_CHARACTERS = {
   logo: require('@/assets/images/tory-logo.png'),
 };
 
-interface ToryEmptyStateProps {
+type ToryEmptyStateProps = {
   variant?: keyof typeof TORY_CHARACTERS;
   title: string;
   description?: string;

--- a/src/shared/data/mock.ts
+++ b/src/shared/data/mock.ts
@@ -2,7 +2,7 @@
  * 목데이터 — 개발/프로토타입용
  */
 
-export interface ThemeCard {
+export type ThemeCard = {
   id: string;
   title: string;
   subtitle: string;
@@ -10,7 +10,7 @@ export interface ThemeCard {
   image?: any;
 }
 
-export interface RecipeCard {
+export type RecipeCard = {
   id: string;
   title: string;
   thumbnailUrl: string;
@@ -21,7 +21,7 @@ export interface RecipeCard {
   cookingTime?: number;
 }
 
-export interface Category {
+export type Category = {
   id: string;
   name: string;
 }

--- a/src/shared/types/auth.d.ts
+++ b/src/shared/types/auth.d.ts
@@ -3,12 +3,12 @@ import { DateOnly } from "../utils/dateOnly";
 
 //레거시 코드
 
-export interface LoginInfo {
+export type LoginInfo = {
   id_token: string;
   provider: OauthProvider;
 }
 
-export interface SignupData {
+export type SignupData = {
   provider: string;
   id_token: string;
   nickname: string;
@@ -19,7 +19,7 @@ export interface SignupData {
   is_terms_of_use_agreed: boolean;
 }
 
-export interface AuthContextType {
+export type AuthContextType = {
   user: any;
   isLoggedIn: boolean;
   loading: boolean;

--- a/src/shared/types/axiosError.d.ts
+++ b/src/shared/types/axiosError.d.ts
@@ -1,10 +1,10 @@
-interface ErrorResponse {
+type ErrorResponse = {
   code: number;
   message: string;
   error: string;
 }
 
-interface ErrorData {
+type ErrorData = {
   message: string;
   error: string;
 }

--- a/src/shared/types/market.d.ts
+++ b/src/shared/types/market.d.ts
@@ -1,11 +1,11 @@
 export type Market = "KOREA" | "GLOBAL";
 
-export interface MarketResponse {
+export type MarketResponse = {
   market: Market;
   country_code: string;
 }
 
-export interface MarketConfig {
+export type MarketConfig = {
   market: Market;
   countryCode: string;
   webviewPath: "/ko" | "/en";

--- a/src/widgets/create-category-view/store/creatingCategoryView.tsx
+++ b/src/widgets/create-category-view/store/creatingCategoryView.tsx
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-interface CreatingCategoryViewStore {
+type CreatingCategoryViewStore = {
   isCreatingOpened: boolean;
   openCreatingView: () => void;
   closeCreatingView: () => void;

--- a/src/widgets/credit-recharge/credit-recharge-sheet.tsx
+++ b/src/widgets/credit-recharge/credit-recharge-sheet.tsx
@@ -17,7 +17,7 @@ const SHARE_TEXT = `🍳 셰프토리에서 레시피 공유하고 맛있는 요
 const TORY_LOGO = require('@/assets/images/tory-logo.png');
 const BERRY_ICON = require('@/assets/images/berry-icon.png');
 
-export interface CreditRechargeSheetRef {
+export type CreditRechargeSheetRef = {
   open: () => void;
   close: () => void;
 }

--- a/src/widgets/ingredient-purchase/ingredient-purchase-sheet.tsx
+++ b/src/widgets/ingredient-purchase/ingredient-purchase-sheet.tsx
@@ -8,7 +8,7 @@ import { useCoupangSearch, type IngredientProduct } from '@/src/entities/affilia
 import { colors, spacing, radius, typography } from '@/src/shared/design/tokens';
 import { track, CoupangEvents } from '@/src/shared/analytics';
 
-export interface IngredientPurchaseSheetRef {
+export type IngredientPurchaseSheetRef = {
   open: (ingredientNames: string[], recipeId?: string) => void;
   close: () => void;
 }

--- a/src/widgets/recipe-report/recipe-report-sheet.tsx
+++ b/src/widgets/recipe-report/recipe-report-sheet.tsx
@@ -16,7 +16,7 @@ const REASONS: { id: RecipeReportReason; label: string; icon: keyof typeof Ionic
   { id: 'OTHER', label: '기타', icon: 'chatbubble-outline', color: '#6B7280' },
 ];
 
-export interface RecipeReportSheetRef {
+export type RecipeReportSheetRef = {
   open: (recipeId: string) => void;
   close: () => void;
 }


### PR DESCRIPTION
## Summary
- API raw 스키마에서 사용 안 하는 fallback 필드 제거 (서버 응답 직접 검증)
- 전체 src에서 `interface` 선언을 `type`으로 일괄 변환 (extends → intersection)
- CLAUDE.md에 type 통일 컨벤션 + interface 금지 룰 추가
- themes.json 큐레이션 순서 변경: 사랑 한 끼 → 밤에 땡기는 → 버터떡 → 봄동 비빔밥 → 두바이 쫀득 쿠키

## Test plan
- [ ] 홈 "이런 요리 어때요" 섹션의 테마 순서 확인
- [ ] 레시피 상세/검색/최근/카테고리 화면이 정상 동작하는지 확인 (스키마 정리 영향)
- [ ] `npx tsc --noEmit` 통과 확인 (interface→type 변환 영향)

🤖 Generated with [Claude Code](https://claude.com/claude-code)